### PR TITLE
OPSEXP-2844 Enable build cache

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -119,19 +119,19 @@ jobs:
         with:
           comment_on_pr: false
 
-      - name: List targets
-        id: generate
+      - name: Enumerate bake targets
+        id: bake-targets
         uses: docker/bake-action/subaction/list-targets@2e3d19baedb14545e5d41222653874f25d5b4dfb  # v5.10.0
         with:
           target: default
 
-      - name: Generate cache targets
+      - name: Enumerate registry cache targets
         id: cache-targets
         env:
           CACHE_TARGET: ${{ env.REGISTRY }}/${{ env.REGISTRY_NAMESPACE }}/bakery-cache
         run: |
           echo 'cache-set<<EOF' >> $GITHUB_OUTPUT
-          echo '${{ steps.generate.outputs.targets }}' | jq -r '.[] | '\
+          echo '${{ steps.bake-targets.outputs.targets }}' | jq -r '.[] | '\
           '"\(.).cache-from=type=registry,ref=${{ env.CACHE_TARGET }}:${{ env.TAG }}-\(.)\n'\
           '\(.).cache-from=type=registry,ref=${{ env.CACHE_TARGET }}:${{ github.event.repository.default_branch }}-\(.)\n'\
           '\(.).cache-to=type=registry,ref=${{ env.CACHE_TARGET }}:${{ env.TAG }}-\(.)"' >> $GITHUB_OUTPUT

--- a/.github/workflows/cleanup_images.yml
+++ b/.github/workflows/cleanup_images.yml
@@ -25,6 +25,7 @@ on:
 env:
   ORG: Alfresco
   REPO: alfresco-dockerfiles-bakery
+  CACHE_REPO: ghcr.io/alfresco/bakery-cache
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number }}${{ inputs.tags }}
@@ -57,10 +58,11 @@ jobs:
           token: ${{ secrets.DELETE_PACKAGES_GITHUB_TOKEN }}
           owner: ${{ env.ORG }}
           repository: ${{ env.REPO }}
-          packages: ${{ env.PACKAGE_NAMES }},ghcr.io/alfresco/bakery-cache
+          packages: ${{ env.PACKAGE_NAMES }},${{ env.CACHE_REPO }}
           delete-tags: ^${{ env.PR_TAG }}$,^${{ env.PR_TAG }}-.*$
           use-regex: true
           dry-run: false
+
       - name: Remove images when requested
         uses: dataaxiom/ghcr-cleanup-action@98b4022383d6ddb70ccbf6a378b4d8c67a60f066 # v1.0.13
         if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
@@ -68,7 +70,7 @@ jobs:
           token: ${{ secrets.DELETE_PACKAGES_GITHUB_TOKEN }}
           owner: ${{ env.ORG }}
           repository: ${{ env.REPO }}
-          packages: ${{ env.PACKAGE_NAMES }},ghcr.io/alfresco/bakery-cache
+          packages: ${{ env.PACKAGE_NAMES }},${{ env.CACHE_REPO }}
           delete-untagged: ${{ github.event_name == 'schedule' || inputs.untagged }}
           delete-tags: ${{ github.event.inputs.tags }}
           dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run || (github.event_name != 'workflow_dispatch' && 'false') }}


### PR DESCRIPTION
OPSEXP-2844

* caches needs to be scoped per bake target to avoid build caches getting overwritten by each other
* we can't use the usual [gha backend](https://docs.docker.com/build/cache/backends/gha/) because it's limited to 10GB and some initial testing showed cache layers being evicted too fast
* [registry cache](https://docs.docker.com/build/cache/backends/registry/) doesn't have size limits but needs to be maintained (not a big deal in this repo)
* to avoid hardcoding cache configuration in each target and triggering failures/warnings when building locally, cache params are dynamically injected in the bake build using the upstream bake targets list action plus the usual jq plumbing