### PR TITLE
Fixup tags cleanup on pr close

### DIFF
--- a/.github/workflows/cleanup_images.yml
+++ b/.github/workflows/cleanup_images.yml
@@ -25,7 +25,7 @@ on:
 env:
   ORG: Alfresco
   REPO: alfresco-dockerfiles-bakery
-  CACHE_REPO: ghcr.io/alfresco/bakery-cache
+  CACHE_REPO: bakery-cache
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number }}${{ inputs.tags }}


### PR DESCRIPTION
I guess the "comma separated" feature is not working anymore once regexp mode is being enabled

https://github.com/Alfresco/alfresco-dockerfiles-bakery/actions/runs/11254998161