### PR TITLE
OPSEXP-2893 Avoid failure in cleanup on pr close

### DIFF
--- a/.github/workflows/cleanup_images.yml
+++ b/.github/workflows/cleanup_images.yml
@@ -58,9 +58,8 @@ jobs:
           token: ${{ secrets.DELETE_PACKAGES_GITHUB_TOKEN }}
           owner: ${{ env.ORG }}
           repository: ${{ env.REPO }}
-          packages: ${{ env.PACKAGE_NAMES }},${{ env.CACHE_REPO }}
-          delete-tags: ^${{ env.PR_TAG }}(-.*)?$ # pr-123 and pr-123-something
-          use-regex: true
+          packages: ${{ env.PACKAGE_NAMES }}
+          delete-tags: ${{ env.PR_TAG }}
           dry-run: false
 
       - name: Remove images when requested


### PR DESCRIPTION
initial workaround for OPSEXP-2893 (we can still delete the entire repo to recover space)