### PR TITLE
OPSEXP-2904 Rename sync image to alfresco-sync-service for consistency

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -783,7 +783,7 @@ target "sync" {
     "org.opencontainers.image.title" = "${PRODUCT_LINE} Sync Service"
     "org.opencontainers.image.description" = "Alfresco Sync Service"
   }
-  tags = ["${REGISTRY}/${REGISTRY_NAMESPACE}/service-sync:${TAG}"]
+  tags = ["${REGISTRY}/${REGISTRY_NAMESPACE}/alfresco-sync-service:${TAG}"]
   output = ["type=docker"]
   platforms = split(",", "${TARGETARCH}")
 }

--- a/sync/README.md
+++ b/sync/README.md
@@ -34,7 +34,7 @@ variable:
 
 ```bash
 docker run -e JAVA_OPTS="-Drepo.hostname=alfresco" \
-  localhost/alfresco/service-sync:latest
+  localhost/alfresco/alfresco-sync-service:latest
 ```
 
 > Set of required properties: https://docs.alfresco.com/sync-service/4.0/config/#required-properties

--- a/test/enterprise-docker-compose.yml
+++ b/test/enterprise-docker-compose.yml
@@ -156,7 +156,7 @@ services:
       - share
       - control-center
   sync-service:
-    image: ${REGISTRY}/${REGISTRY_NAMESPACE}/service-sync:${TAG}
+    image: ${REGISTRY}/${REGISTRY_NAMESPACE}/alfresco-sync-service:${TAG}
     mem_limit: 1g
     environment:
       JAVA_OPTS: >-

--- a/test/helm/test-overrides.yaml
+++ b/test/helm/test-overrides.yaml
@@ -76,7 +76,7 @@ alfresco-digital-workspace:
             path: app.config.json
 alfresco-sync-service:
   image:
-    repository: localhost/alfresco/service-sync
+    repository: localhost/alfresco/alfresco-sync-service
     tag: latest
 alfresco-control-center:
   image:


### PR DESCRIPTION
### Description

The existing service-sync image is the only one that lacks the alfresco- prefix. We are not aware of any limitations that would prevent us from maintaining consistency in the naming of this image with the others currently in use.

### Related Issue

OPSEXP-2904

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have updated the documentation accordingly.
