### PR TITLE
Fine-tune CI from forked repos

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -41,6 +41,7 @@ permissions:
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
+    if: '! github.event.pull_request.head.repo.fork'
     permissions:
       contents: write
     steps:

--- a/.github/workflows/build_forks.yml
+++ b/.github/workflows/build_forks.yml
@@ -4,8 +4,6 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - '.github/workflows/build_forks.yml'
   push:
     branches:
       - main


### PR DESCRIPTION
### Description

Allow forked workflow for any change and prevent running main CI for PRs coming from forks.

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have updated the documentation accordingly.
