### PR TITLE
Make it challenging for people to checkin their .netrc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.netrc
 artifacts_cache
 *.zip
 *.amp


### PR DESCRIPTION
### Description

Given we are directing folks to add secrets to their .netrc we should add this file to .gitignore so they are less tempted to check in secrets.

### Related Issue

NA

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have updated the documentation accordingly.
