### PR TITLE
OPSEXP-2915 Improve compose testing docs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -165,7 +165,7 @@ jobs:
 
       - name: Merge Docker Compose files
         env:
-          UPSTREAM_COMPOSE_PATH: test/${{ matrix.edition == 'community'&& 'community-' }}compose.yaml
+          UPSTREAM_COMPOSE_PATH: test/${{ matrix.edition == 'community' && 'community-' || '' }}compose.yaml
           OVERRIDE_COMPOSE_PATH: test/${{ matrix.edition }}-override.yaml
         run: docker compose -f ${{ env.UPSTREAM_COMPOSE_PATH }} -f ${{ env.OVERRIDE_COMPOSE_PATH }} config > ${{ env.MERGED_COMPOSE_PATH }}
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -145,8 +145,6 @@ jobs:
       matrix:
         edition: [enterprise, community]
     env:
-      UPSTREAM_COMPOSE_PATH: test/${{ matrix.edition }}.yaml
-      OVERRIDE_COMPOSE_PATH: test/${{ matrix.edition }}-override.yaml
       MERGED_COMPOSE_PATH: test/merged-compose.yaml
     steps:
       - name: Checkout
@@ -163,9 +161,12 @@ jobs:
         uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349  # v3.7.1
 
       - name: Fetch compose from acs-deployment
-        run: ./scripts/fetch-compose.sh ${{ matrix.edition }} ${{ env.UPSTREAM_COMPOSE_PATH }} ${{ env.ACS_DEPLOYMENT_VERSION }}
+        run: ./scripts/fetch-compose.sh ${{ env.ACS_DEPLOYMENT_VERSION }}
 
       - name: Merge Docker Compose files
+        env:
+          UPSTREAM_COMPOSE_PATH: test/${{ matrix.edition == 'community'&& 'community-' }}compose.yaml
+          OVERRIDE_COMPOSE_PATH: test/${{ matrix.edition }}-override.yaml
         run: docker compose -f ${{ env.UPSTREAM_COMPOSE_PATH }} -f ${{ env.OVERRIDE_COMPOSE_PATH }} config > ${{ env.MERGED_COMPOSE_PATH }}
 
       - name: Verify docker-compose (${{ matrix.edition }})

--- a/.github/workflows/build_forks.yml
+++ b/.github/workflows/build_forks.yml
@@ -80,7 +80,6 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     env:
-      EDITION: community
       MERGED_COMPOSE_PATH: test/merged-compose.yaml
     steps:
       - name: Checkout
@@ -98,10 +97,13 @@ jobs:
           docker image ls -a
 
       - name: Fetch compose from acs-deployment
-        run: ./scripts/fetch-compose.sh ${{ env.EDITION }} test/${{ env.EDITION }}.yaml ${{ env.ACS_DEPLOYMENT_VERSION }}
+        run: ./scripts/fetch-compose.sh ${{ env.ACS_DEPLOYMENT_VERSION }}
 
       - name: Merge Docker Compose files
-        run: docker compose -f test/${{ env.EDITION }}.yaml -f test/${{ env.EDITION }}-override.yaml config > ${{ env.MERGED_COMPOSE_PATH }}
+        env:
+          UPSTREAM_COMPOSE_PATH: test/community-compose.yaml
+          OVERRIDE_COMPOSE_PATH: test/community-override.yaml
+        run: docker compose -f ${{ env.UPSTREAM_COMPOSE_PATH }} -f ${{ env.OVERRIDE_COMPOSE_PATH }} config > ${{ env.MERGED_COMPOSE_PATH }}
 
       - name: Verify docker-compose
         id: verify_compose

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,6 @@ artifacts_cache
 *.gz
 *.tgz
 
+test/compose.yaml
+test/community-compose.yaml
 test/helm/enterprise-integration-test-values.yaml

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Bake](https://docs.docker.com/build/bake/).
     - [Targeting a specific architecture](#targeting-a-specific-architecture)
     - [Multi-arch images](#multi-arch-images)
   - [Testing locally](#testing-locally)
-    - [With helm](#with-helm)
-    - [With docker compose](#with-docker-compose)
+    - [Testing with helm](#testing-with-helm)
+    - [Testing with docker compose](#testing-with-docker-compose)
   - [Security scanning](#security-scanning)
 
 ## Prerequisites
@@ -198,7 +198,9 @@ docker buildx bake repo --set *.output=type=registry,push=true
 
 ## Testing locally
 
-### With helm
+Once the images are built, you can test them locally using either Helm or Docker Compose.
+
+### Testing with helm
 
 You can easily load all the built image in a local kind cluster with:
 
@@ -209,7 +211,7 @@ kind load docker-image $(docker images --format "{{.Repository}}" | grep "^local
 Then you can run an helm install passing as values the provided
 [test-overrides.yaml](./test/helm/test-overrides.yaml).
 
-### With docker compose
+### Testing with docker compose
 
 You can use Docker Compose to test the built images locally as follows:
 

--- a/README.md
+++ b/README.md
@@ -209,22 +209,32 @@ kind load docker-image $(docker images --format "{{.Repository}}" | grep "^local
 Then you can run an helm install passing as values the provided
 [test-overrides.yaml](./test/helm/test-overrides.yaml).
 
-
 ### With docker compose
 
-You can use docker compose to test locally with:
+You can use Docker Compose to test the built images locally as follows:
 
-1. Fetch compose from acs-deployment repo using `scripts/fetch-compose.sh` script e.g.:
+1. Fetch upstream compose from acs-deployment repository using the provided
+   script (you can specify a git branch or tag):
 
-```sh
-./scripts/fetch-compose.sh enterprise test/compose.yaml master
-```
+   ```sh
+   ./scripts/fetch-compose.sh master
+   ```
 
-2. Run the compose with overriding file
+2. Run compose together with one of the available override files, which allow
+   you to easily reference built images using
+   `$REGISTRY/$REGISTRY_NAMESPACE/component-name:$TAG` format:
 
-```sh
-docker compose -f test/compose.yaml -f test/enterprise-override.yaml up
-```
+   ```sh
+   REGISTRY=localhost REGISTRY_NAMESPACE=alfresco TAG=latest
+   docker compose -f test/compose.yaml -f test/enterprise-override.yaml up -d
+   ```
+
+   For community edition instead:
+
+    ```sh
+    REGISTRY=localhost REGISTRY_NAMESPACE=alfresco TAG=latest
+    docker compose -f test/community-compose.yaml -f test/community-override.yaml up -d
+    ```
 
 ## Security scanning
 

--- a/scripts/fetch-compose.sh
+++ b/scripts/fetch-compose.sh
@@ -1,25 +1,27 @@
-#!/bin/bash
+#!/bin/bash -e
 
-if [ "$#" -ne 3 ]; then
-  echo "Usage: $0 <enterprise|community> <destination-filename> <acs-version>" >&2
+usage() {
+  echo "Usage: $0 <acs-deployment-version>" >&2
   exit 1
+}
+
+if [ "$#" -ne 1 ]; then
+  usage
 fi
 
-if [ "$1" = "enterprise" ]; then
-  COMPOSE_FILE="compose.yaml"
-else
-  COMPOSE_FILE="community-compose.yaml"
-fi
+ACS_DEPLOYMENT_VERSION="$1"
+COMPOSE_FILES=(compose.yaml community-compose.yaml)
+DESTINATION_DIR="$(dirname "$0")/../test"
 
-COMPOSE_URL="https://raw.githubusercontent.com/Alfresco/acs-deployment/$3/docker-compose/${COMPOSE_FILE}"
-
-DESTINATION_PATH="$2"
-
-echo "Downloading compose file from ${COMPOSE_URL}..."
-wget -O "${DESTINATION_PATH}" "${COMPOSE_URL}"
-if [ $? -eq 0 ]; then
-  echo "Compose file downloaded successfully to ${DESTINATION_PATH}"
-else
-  echo "Failed to download compose file" >&2
-  exit 1
-fi
+for COMPOSE_FILE in "${COMPOSE_FILES[@]}"; do
+  COMPOSE_URL="https://raw.githubusercontent.com/Alfresco/acs-deployment/${ACS_DEPLOYMENT_VERSION}/docker-compose/${COMPOSE_FILE}"
+  DESTINATION_PATH="${DESTINATION_DIR}/${COMPOSE_FILE}"
+  echo "Downloading upstream acs-deployment compose file..."
+  if wget -O "${DESTINATION_PATH}" --no-verbose "${COMPOSE_URL}"; then
+    echo "Compose file downloaded successfully to ${DESTINATION_PATH}"
+  else
+    echo "Failed to download compose file" >&2
+    rm -f "${DESTINATION_PATH}"
+    exit 1
+  fi
+done


### PR DESCRIPTION
### Description

Simplified the fetch script to download both enterprise and community compose from acs-deployment, the only argument is the version of acs-deployment.

Clarified how to leverage environment variables to test the desired built images.

### Related Issue

OPSEXP-2915
#103 

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have updated the documentation accordingly.
