### PR TITLE
OPSEXP-2919 Prevent incomplete downloads in cache folder

### DIFF
--- a/scripts/fetch-artifacts.sh
+++ b/scripts/fetch-artifacts.sh
@@ -2,6 +2,7 @@
 # Fetch artifact from Nexus which will be used to build the Docker image
 
 REPO_ROOT="$(dirname $0)/.."
+TEMP_DIR=$(mktemp -d)
 
 ACS_VERSION=${ACS_VERSION:=23.2.2}
 INDEX_KEY=${ACS_VERSION%%.*}
@@ -15,25 +16,27 @@ do_fetch_mvn() {
     ARTIFACT_GROUP=$(jq -r ".artifacts.acs${INDEX_KEY}[$i].group" $1)
     ARTIFACT_PATH=$(jq -r ".artifacts.acs${INDEX_KEY}[$i].path" $1)
     ARTIFACT_BASEURL="https://nexus.alfresco.com/nexus/repository/${ARTIFACT_REPO}"
+    ARTIFACT_TMP_PATH="${TEMP_DIR}/${ARTIFACT_NAME}-${ARTIFACT_VERSION}${ARTIFACT_EXT}"
     ARTIFACT_CACHE_PATH="${REPO_ROOT}/artifacts_cache/${ARTIFACT_NAME}-${ARTIFACT_VERSION}${ARTIFACT_EXT}"
     ARTIFACT_FINAL_PATH="${ARTIFACT_PATH}/${ARTIFACT_NAME}-${ARTIFACT_VERSION}${ARTIFACT_EXT}"
     echo # newline for better readability
     if [ -f "${ARTIFACT_FINAL_PATH}" ]; then
-      echo "Artifact $ARTIFACT_NAME-$ARTIFACT_VERSION already downloaded, skipping..."
+      echo "Artifact $ARTIFACT_NAME-$ARTIFACT_VERSION already present, skipping..."
       continue
     fi
     if [ -f "${ARTIFACT_CACHE_PATH}" ]; then
-      echo "Artifact $ARTIFACT_NAME-$ARTIFACT_VERSION already downloaded in cache, copying..."
+      echo "Artifact $ARTIFACT_NAME-$ARTIFACT_VERSION already present in cache, copying..."
       cp "${ARTIFACT_CACHE_PATH}" "${ARTIFACT_FINAL_PATH}"
       continue
     fi
     echo "Downloading $ARTIFACT_GROUP:$ARTIFACT_NAME $ARTIFACT_VERSION from $ARTIFACT_BASEURL"
     if ! wget "${ARTIFACT_BASEURL}/${ARTIFACT_GROUP//\./\/}/${ARTIFACT_NAME}/${ARTIFACT_VERSION}/${ARTIFACT_NAME}-${ARTIFACT_VERSION}${ARTIFACT_EXT}" \
-      -O "${ARTIFACT_CACHE_PATH}" \
+      -O "${ARTIFACT_TMP_PATH}" \
       --no-verbose; then
-      rm -f "${ARTIFACT_CACHE_PATH}" # wget leaves a 0 byte file if it fails
+      rm -f "${ARTIFACT_TMP_PATH}" # wget leaves a 0 byte file if it fails
       echo "Skipping after wget failure..."
     else
+      mv "${ARTIFACT_TMP_PATH}" "${ARTIFACT_CACHE_PATH}"
       cp "${ARTIFACT_CACHE_PATH}" "${ARTIFACT_FINAL_PATH}"
     fi
   done

--- a/scripts/fetch-artifacts.sh
+++ b/scripts/fetch-artifacts.sh
@@ -30,7 +30,7 @@ do_fetch_mvn() {
       continue
     fi
     echo "Downloading $ARTIFACT_GROUP:$ARTIFACT_NAME $ARTIFACT_VERSION from $ARTIFACT_BASEURL"
-    if ! wget "${ARTIFACT_BASEURL}/${ARTIFACT_GROUP//\./\/}/${ARTIFACT_NAME}/${ARTIFACT_VERSION}/${ARTIFACT_NAME}-${ARTIFACT_VERSION}${ARTIFACT_EXT}" \
+    if ! wget "${ARTIFACT_BASEURL}/${ARTIFACT_GROUP//\.//}/${ARTIFACT_NAME}/${ARTIFACT_VERSION}/${ARTIFACT_NAME}-${ARTIFACT_VERSION}${ARTIFACT_EXT}" \
       -O "${ARTIFACT_TMP_PATH}" \
       --no-verbose; then
       rm -f "${ARTIFACT_TMP_PATH}" # wget leaves a 0 byte file if it fails


### PR DESCRIPTION
### Description

Doing the initial wget to tmp folder which should prevent any further incomplete download to pollute the cache folder and build workspaces.

### Related Issue

https://github.com/Alfresco/alfresco-dockerfiles-bakery/issues/104#issuecomment-2450932644
OPSEXP-2919

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have updated the documentation accordingly.
