### PR TITLE
OPSEXP-2926: do not delete the artifact cache directory on make clean_caches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ clean_caches:
 	@echo "Cleaning up Docker cache"
 	docker builder prune -f
 	@echo "Cleaning up Artifacts cache"
-	rm -fr artifacts_cache
+	find artifacts_cache/ ! -name .gitkeep -mindepth 1 -delete
 
 ## PREPARE TARGETS
 ## Keep targets in alphabetical order (following the folder structure)


### PR DESCRIPTION
### Description

do not delete the artifact cache directory on make clean_caches

### Related Issue

Ref: OPSEXP-2926

### Checklist

- [x] My code follows the project's coding standards.
- [ n/a] I have updated the documentation accordingly.
