### PR TITLE
OPSEXP-2922  Ensure Tomcat version variables are exported as environment variables in Makefile for Docker Bake

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,9 +37,9 @@ else
   TOMCAT_FIELD := "tomcat9"
 endif
 
-TOMCAT_MAJOR := $(shell yq e '.${TOMCAT_FIELD}.major' $(TOMCAT_VERSIONS_FILE))
-TOMCAT_VERSION := $(shell yq e '.${TOMCAT_FIELD}.version' $(TOMCAT_VERSIONS_FILE))
-TOMCAT_SHA512 := $(shell yq e '.${TOMCAT_FIELD}.sha512' $(TOMCAT_VERSIONS_FILE))
+export TOMCAT_MAJOR := $(shell yq e '.${TOMCAT_FIELD}.major' $(TOMCAT_VERSIONS_FILE))
+export TOMCAT_VERSION := $(shell yq e '.${TOMCAT_FIELD}.version' $(TOMCAT_VERSIONS_FILE))
+export TOMCAT_SHA512 := $(shell yq e '.${TOMCAT_FIELD}.sha512' $(TOMCAT_VERSIONS_FILE))
 
 setenv: auth
 ifdef BAKE_NO_CACHE


### PR DESCRIPTION
### Description

Fixing bug that was causing older versions not to pick up the proper version of Tomcat. Makefile was not setting tomcat versions vars as env vars - bake could not use them.
### Related Issue

OPSEXP-2922

### Checklist

- [x] My code follows the project's coding standards.
- [ ] I have updated the documentation accordingly.
