### PR TITLE
OPSEXP-2893 Add step which cleans the bakery-cache tags older than given period

### DIFF
--- a/.github/workflows/cleanup_images.yml
+++ b/.github/workflows/cleanup_images.yml
@@ -82,6 +82,7 @@ jobs:
           owner: ${{ env.ORG }}
           repository: ${{ env.REPO }}
           packages: ${{ env.CACHE_REPO }}
+          delete-untagged: false
           older-than: ${{ env.PERIOD }}
           dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run || (github.event_name != 'workflow_dispatch' && 'false') }}
 

--- a/.github/workflows/cleanup_images.yml
+++ b/.github/workflows/cleanup_images.yml
@@ -87,15 +87,15 @@ jobs:
           older-than: ${{ env.PERIOD }}
           dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run || (github.event_name != 'workflow_dispatch' && 'false') }}
 
-      # - name: Remove images when requested
-      #   uses: dataaxiom/ghcr-cleanup-action@98b4022383d6ddb70ccbf6a378b4d8c67a60f066 # v1.0.13
-      #   if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-      #   with:
-      #     token: ${{ secrets.DELETE_PACKAGES_GITHUB_TOKEN }}
-      #     owner: ${{ env.ORG }}
-      #     repository: ${{ env.REPO }}
-      #     packages: ${{ env.PACKAGE_NAMES }},${{ env.CACHE_REPO }}
-      #     delete-untagged: ${{ github.event_name == 'schedule' || inputs.untagged }}
-      #     delete-tags: ${{ github.event.inputs.tags }}
-      #     use-regex: true
-      #     dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run || (github.event_name != 'workflow_dispatch' && 'false') }}
+      - name: Remove images when requested
+        uses: dataaxiom/ghcr-cleanup-action@98b4022383d6ddb70ccbf6a378b4d8c67a60f066 # v1.0.13
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        with:
+          token: ${{ secrets.DELETE_PACKAGES_GITHUB_TOKEN }}
+          owner: ${{ env.ORG }}
+          repository: ${{ env.REPO }}
+          packages: ${{ env.PACKAGE_NAMES }},${{ env.CACHE_REPO }}
+          delete-untagged: ${{ github.event_name == 'schedule' || inputs.untagged }}
+          delete-tags: ${{ github.event.inputs.tags }}
+          use-regex: true
+          dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run || (github.event_name != 'workflow_dispatch' && 'false') }}

--- a/.github/workflows/cleanup_images.yml
+++ b/.github/workflows/cleanup_images.yml
@@ -62,6 +62,19 @@ jobs:
           delete-tags: ${{ env.PR_TAGS }}
           dry-run: false
 
+      - name: Remove ${{ env.CACHE_REPO }} tags older than ${{ env.PERIOD }} after PR is closed
+        uses: dataaxiom/ghcr-cleanup-action@98b4022383d6ddb70ccbf6a378b4d8c67a60f066 # v1.0.13
+        if: github.event_name == 'pull_request'
+        env:
+          PERIOD: 2 weeks
+        with:
+          token: ${{ secrets.DELETE_PACKAGES_GITHUB_TOKEN }}
+          owner: ${{ env.ORG }}
+          repository: ${{ env.REPO }}
+          packages: ${{ env.CACHE_REPO }}
+          older-than: ${{ env.PERIOD }}
+          dry-run: false
+
       - name: Remove images when requested
         uses: dataaxiom/ghcr-cleanup-action@98b4022383d6ddb70ccbf6a378b4d8c67a60f066 # v1.0.13
         if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/cleanup_images.yml
+++ b/.github/workflows/cleanup_images.yml
@@ -83,6 +83,7 @@ jobs:
           repository: ${{ env.REPO }}
           packages: ${{ env.CACHE_REPO }}
           delete-untagged: false
+          log-level: debug
           older-than: ${{ env.PERIOD }}
           dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run || (github.event_name != 'workflow_dispatch' && 'false') }}
 

--- a/.github/workflows/cleanup_images.yml
+++ b/.github/workflows/cleanup_images.yml
@@ -87,15 +87,15 @@ jobs:
           older-than: ${{ env.PERIOD }}
           dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run || (github.event_name != 'workflow_dispatch' && 'false') }}
 
-      - name: Remove images when requested
-        uses: dataaxiom/ghcr-cleanup-action@98b4022383d6ddb70ccbf6a378b4d8c67a60f066 # v1.0.13
-        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-        with:
-          token: ${{ secrets.DELETE_PACKAGES_GITHUB_TOKEN }}
-          owner: ${{ env.ORG }}
-          repository: ${{ env.REPO }}
-          packages: ${{ env.PACKAGE_NAMES }},${{ env.CACHE_REPO }}
-          delete-untagged: ${{ github.event_name == 'schedule' || inputs.untagged }}
-          delete-tags: ${{ github.event.inputs.tags }}
-          use-regex: true
-          dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run || (github.event_name != 'workflow_dispatch' && 'false') }}
+      # - name: Remove images when requested
+      #   uses: dataaxiom/ghcr-cleanup-action@98b4022383d6ddb70ccbf6a378b4d8c67a60f066 # v1.0.13
+      #   if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+      #   with:
+      #     token: ${{ secrets.DELETE_PACKAGES_GITHUB_TOKEN }}
+      #     owner: ${{ env.ORG }}
+      #     repository: ${{ env.REPO }}
+      #     packages: ${{ env.PACKAGE_NAMES }},${{ env.CACHE_REPO }}
+      #     delete-untagged: ${{ github.event_name == 'schedule' || inputs.untagged }}
+      #     delete-tags: ${{ github.event.inputs.tags }}
+      #     use-regex: true
+      #     dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run || (github.event_name != 'workflow_dispatch' && 'false') }}

--- a/.github/workflows/cleanup_images.yml
+++ b/.github/workflows/cleanup_images.yml
@@ -21,6 +21,16 @@ on:
         required: false
         type: boolean
         default: false
+      clean-old-cache:
+        description: Delete old cache images
+        required: false
+        type: boolean
+        default: false
+      old-cache-period:
+        description: Period to keep cache images
+        required: false
+        type: string
+        default: 2 weeks
 
 env:
   ORG: Alfresco
@@ -62,18 +72,18 @@ jobs:
           delete-tags: ${{ env.PR_TAGS }}
           dry-run: false
 
-      - name: Remove ${{ env.CACHE_REPO }} tags older than ${{ env.PERIOD }} after PR is closed
+      - name: Remove ${{ env.CACHE_REPO }} tags older than ${{ env.PERIOD }} when requested
         uses: dataaxiom/ghcr-cleanup-action@98b4022383d6ddb70ccbf6a378b4d8c67a60f066 # v1.0.13
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.clean-old-cache)
         env:
-          PERIOD: 2 weeks
+          PERIOD: ${{ github.event_name == 'workflow_dispatch' && inputs.old-cache-period || (github.event_name != 'workflow_dispatch' && '2 weeks') }}
         with:
           token: ${{ secrets.DELETE_PACKAGES_GITHUB_TOKEN }}
           owner: ${{ env.ORG }}
           repository: ${{ env.REPO }}
           packages: ${{ env.CACHE_REPO }}
           older-than: ${{ env.PERIOD }}
-          dry-run: false
+          dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run || (github.event_name != 'workflow_dispatch' && 'false') }}
 
       - name: Remove images when requested
         uses: dataaxiom/ghcr-cleanup-action@98b4022383d6ddb70ccbf6a378b4d8c67a60f066 # v1.0.13

--- a/.github/workflows/cleanup_images.yml
+++ b/.github/workflows/cleanup_images.yml
@@ -83,7 +83,7 @@ jobs:
           repository: ${{ env.REPO }}
           packages: ${{ env.CACHE_REPO }}
           delete-untagged: false
-          log-level: debug
+          keep-n-tagged: 0
           older-than: ${{ env.PERIOD }}
           dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run || (github.event_name != 'workflow_dispatch' && 'false') }}
 


### PR DESCRIPTION
### Description

Added step in cleanup images workflow which cleans the bakery-cache repo from the tags older than 2 weeks when requested (scheduled job or workflow dispatch) 

### Related Issue

ref: OPSEXP-2893

### Checklist

- [x] My code follows the project's coding standards.
- [ ] I have updated the documentation accordingly.
