### PR TITLE
OPSEXP-2932 Point links to support.hyland.com

### DIFF
--- a/repository/amps/README.md
+++ b/repository/amps/README.md
@@ -4,17 +4,13 @@ Place here your Alfresco module Packages (AMPs) to be installed in the Alfresco
 repository.
 
 AMP packages should have the `.amp` extension and stick to the Alfresco module
-packaging format as described in the [Alfresco
-documentation](https://docs.alfresco.com/content-services/latest/develop/extension-packaging/#alfresco-module-package-amp).
+packaging format as described in the [Alfresco documentation][amp].
 
-The [in-process Alfresco
-SDK](https://docs.alfresco.com/content-services/latest/develop/sdk/) provides a
-way to build well structured AMPs.
+The [in-process Alfresco SDK][sdk] provides a way to build well structured AMPs.
 
 > Note that AMPs are not the recommanded way to extend Alfresco. You should
 > prefer using the Alfresco SDK to build your extensions as JARs even better,
-> use the [out-of-process Alfresco
-> SDK](https://docs.alfresco.com/content-services/latest/develop/oop-sdk/) to
+> use the [out-of-process AlfrescoSDK][oop] to
 > build Docker images with your extensions.
 
 By default the `scripts/fetch-artifacts.sh` script will fetch only the default
@@ -23,3 +19,7 @@ AMPs, see [artifacts.json](../artifacts.json) for additional information.
 You can replace those, remove them to keep only the ones you need or add more.
 Be careful though as some AMPs may depend on one another (e.g.
 `googldrive-repo` depends on `alfresco-share-services`).
+
+[sdk]: https://support.hyland.com/r/Alfresco/Alfresco-In-Process-SDK/4.10/Alfresco-In-Process-SDK/Introduction
+[oop]: https://support.hyland.com/r/Alfresco/Alfresco-Content-Services/23.4/Alfresco-Content-Services/Develop/Out-of-Process-Extension-Points/Events-Extension-Point
+[amp]: https://support.hyland.com/r/Alfresco/Alfresco-Content-Services/23.4/Alfresco-Content-Services/Develop/Extension-Packaging-Modules/Module-Package-Formats/Alfresco-Module-Package-AMP

--- a/share/amps/README.md
+++ b/share/amps/README.md
@@ -4,17 +4,13 @@ Place here your Alfresco module Packages (AMPs) to be installed in the Alfresco
 share.
 
 AMP packages should have the `.amp` extension and stick to the Alfresco module
-packaging format as described in the [Alfresco
-documentation](https://docs.alfresco.com/content-services/latest/develop/extension-packaging/#alfresco-module-package-amp).
+packaging format as described in the [Alfresco documentation][amp].
 
-The [in-process Alfresco
-SDK](https://docs.alfresco.com/content-services/latest/develop/sdk/) provides a
-way to build well structured AMPs.
+The [in-process Alfresco SDK][sdk] provides a way to build well structured AMPs.
 
 > Note that AMPs are not the recommanded way to extend Alfresco. You should
 > prefer using the Alfresco SDK to build your extensions as JARs even better,
-> use the [out-of-process Alfresco
-> SDK](https://docs.alfresco.com/content-services/latest/develop/oop-sdk/) to
+> use the [out-of-process Alfresco SDK][oop] to
 > build Docker images with your extensions.
 
 By default the `scripts/fetch-artifacts.sh` script will fetch the following AMPs from the Alfresco Nexus repository:
@@ -22,3 +18,7 @@ By default the `scripts/fetch-artifacts.sh` script will fetch the following AMPs
 * alfresco-googledrive-share
 
 You can replace those, remove them to keep only the ones you need or add more.
+
+[sdk]: https://support.hyland.com/r/Alfresco/Alfresco-In-Process-SDK/4.10/Alfresco-In-Process-SDK/Introduction
+[oop]: https://support.hyland.com/r/Alfresco/Alfresco-Content-Services/23.4/Alfresco-Content-Services/Develop/Out-of-Process-Extension-Points/Events-Extension-Point
+[amp]: https://support.hyland.com/r/Alfresco/Alfresco-Content-Services/23.4/Alfresco-Content-Services/Develop/Extension-Packaging-Modules/Module-Package-Formats/Alfresco-Module-Package-AMP

--- a/sync/README.md
+++ b/sync/README.md
@@ -37,8 +37,10 @@ docker run -e JAVA_OPTS="-Drepo.hostname=alfresco" \
   localhost/alfresco/alfresco-sync-service:latest
 ```
 
-> Set of required properties: https://docs.alfresco.com/sync-service/4.0/config/#required-properties
+> Set of required properties: [sync]
 
 > If the image is meant to be used with the Alfresco Content Services Helm
 > chart, you can use other [higher level means of
 > configuration](https://github.com/Alfresco/alfresco-helm-charts/blob/main/charts/alfresco-sync-service/README.md).
+
+[sync]: https://support.hyland.com/r/Alfresco/Alfresco-Sync-Service/5.1/Alfresco-Sync-Service/Configure/Overview/Required-properties


### PR DESCRIPTION
### Description

Link which used to point to [docs.alfresco.com](http://docs.alfresco.com/) needs to be changed to point to [support.hyland.com](http://support.hyland.com/) 

### Related Issue

OPSEXP-2932 

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have updated the documentation accordingly.
