### PR TITLE
OPSEXP-3082 Cleanup old tags from all repositories

### DIFF
--- a/.github/workflows/cleanup_images.yml
+++ b/.github/workflows/cleanup_images.yml
@@ -9,26 +9,21 @@ on:
     inputs:
       dry-run:
         description: Dry run (do not delete images)
-        required: false
         type: boolean
         default: true
       tags:
         description: Tags to delete for all the images (regexp enabled)
-        required: false
         type: string
       untagged:
         description: Delete untagged images
-        required: false
         type: boolean
         default: false
-      clean-old-cache:
-        description: Delete old cache images
-        required: false
+      cleanup-old-tags:
+        description: Remove old tags from every repository
         type: boolean
         default: false
-      old-cache-period:
-        description: Period to keep cache images
-        required: false
+      cleanup-old-tags-period:
+        description: Keep tags newer than this period
         type: string
         default: 2 weeks
 
@@ -79,11 +74,11 @@ jobs:
           delete-tags: ${{ env.PR_TAGS }}
           dry-run: false
 
-      - name: Remove ${{ env.CACHE_REPO }} tags older than ${{ env.PERIOD }} when requested
+      - name: Remove every repo tags older than ${{ env.PERIOD }}
         uses: dataaxiom/ghcr-cleanup-action@2d58aab3d24aed94070e032d3091b83d50d93534 # v1.0.15
-        if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.clean-old-cache)
+        if: inputs.cleanup-old-tags || github.event_name == 'schedule'
         env:
-          PERIOD: ${{ github.event_name == 'workflow_dispatch' && inputs.old-cache-period || (github.event_name != 'workflow_dispatch' && '2 weeks') }}
+          PERIOD: ${{ github.event_name == 'workflow_dispatch' && inputs.cleanup-old-tags-period || (github.event_name != 'workflow_dispatch' && '2 weeks') }}
         with:
           token: ${{ secrets.DELETE_PACKAGES_GITHUB_TOKEN }}
           owner: ${{ env.ORG }}

--- a/.github/workflows/cleanup_images.yml
+++ b/.github/workflows/cleanup_images.yml
@@ -83,7 +83,7 @@ jobs:
           token: ${{ secrets.DELETE_PACKAGES_GITHUB_TOKEN }}
           owner: ${{ env.ORG }}
           repository: ${{ env.REPO }}
-          packages: ${{ env.CACHE_REPO }}
+          packages: ${{ env.PACKAGE_NAMES }},${{ env.CACHE_REPO }}
           delete-untagged: false
           keep-n-tagged: 0
           older-than: ${{ env.PERIOD }}

--- a/.github/workflows/cleanup_images.yml
+++ b/.github/workflows/cleanup_images.yml
@@ -78,7 +78,7 @@ jobs:
         uses: dataaxiom/ghcr-cleanup-action@2d58aab3d24aed94070e032d3091b83d50d93534 # v1.0.15
         if: inputs.cleanup-old-tags || github.event_name == 'schedule'
         env:
-          PERIOD: ${{ github.event_name == 'workflow_dispatch' && inputs.cleanup-old-tags-period || (github.event_name != 'workflow_dispatch' && '2 weeks') }}
+          PERIOD: ${{ inputs.cleanup-old-tags-period || '2 weeks' }}
         with:
           token: ${{ secrets.DELETE_PACKAGES_GITHUB_TOKEN }}
           owner: ${{ env.ORG }}
@@ -87,7 +87,7 @@ jobs:
           delete-untagged: false
           keep-n-tagged: 0
           older-than: ${{ env.PERIOD }}
-          dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run || (github.event_name != 'workflow_dispatch' && 'false') }}
+          dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run || 'false' }}
 
       - name: Remove images when requested
         uses: dataaxiom/ghcr-cleanup-action@2d58aab3d24aed94070e032d3091b83d50d93534 # v1.0.15
@@ -100,4 +100,4 @@ jobs:
           delete-untagged: ${{ github.event_name == 'schedule' || inputs.untagged }}
           delete-tags: ${{ github.event.inputs.tags }}
           use-regex: true
-          dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run || (github.event_name != 'workflow_dispatch' && 'false') }}
+          dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run || 'false' }}


### PR DESCRIPTION
### Description

We are currently deleting older tags only for the cache repository, but since we previously had a failure in cleanup of tags on pr close now we have a fair amount of tags present in every repository which could be simply deleted as we are not really publishing/using these images anywhere else.

### Related Issue

OPSEXP-3082

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have updated the documentation accordingly.
