### PR TITLE
OPSEXP-3247 Fixup repository amp idempotency and uniform install-mmt cmd

### DIFF
--- a/repository/Dockerfile
+++ b/repository/Dockerfile
@@ -40,7 +40,8 @@ RUN if [ -f /tmp/amps/alfresco-aos-module-*.amp ]; then umask 0027; \
      unzip ${DISTDIR}/web-server/webapps/_vti_bin.war -d ${CATALINA_HOME}/webapps/_vti_bin/; \
    else echo "No AOS module found"; \
    fi
-RUN java -jar ${DISTDIR}/bin/alfresco-mmt.jar install /tmp/amps/ ${CATALINA_HOME}/webapps/alfresco -nobackup -directory && \
+RUN java -jar ${DISTDIR}/bin/alfresco-mmt.jar install \
+    /tmp/amps/ ${CATALINA_HOME}/webapps/alfresco -directory -nobackup -force && \
     java -jar ${DISTDIR}/bin/alfresco-mmt.jar list ${CATALINA_HOME}/webapps/alfresco
 
 COPY simple_modules /tmp/simple_modules

--- a/share/Dockerfile
+++ b/share/Dockerfile
@@ -31,7 +31,8 @@ RUN sed -i "s/shared.loader=/shared.loader=\${catalina.base}\/shared\/classes/" 
 RUN chmod +x ${CATALINA_HOME}/shared/classes/alfresco/entrypoint.sh
 
 RUN java -jar ${DISTDIR}/bin/alfresco-mmt.jar install \
-    /tmp/amps/ ${CATALINA_HOME}/webapps/share -directory -nobackup -force
+    /tmp/amps/ ${CATALINA_HOME}/webapps/share -directory -nobackup -force && \
+    java -jar ${DISTDIR}/bin/alfresco-mmt.jar list ${CATALINA_HOME}/webapps/share
 
 COPY simple_modules /tmp/simple_modules
 RUN mkdir -m 750 -p ${CATALINA_HOME}/modules/share && \


### PR DESCRIPTION
### Description

Rebuilding repository image twice will fail because `install-mmt` will halt finding an already applied amp in the final war.

### Related Issue

OPSEXP-3247

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have updated the documentation accordingly.
