### PR TITLE
OPSEXP-3247 Reference Vagrantfile availability in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Building images requires the following tools:
 - Python 3 with pyyaml (`pip install pyyaml`) for fetching artifacts via the
   `fetch-artifacts.py` script
 
-Alternatively, you can use the provided `Vagrantfile` to create a Virtualbox VM
+Alternatively, you can use the provided `Vagrantfile` to create a VirtualBox VM
 with all the required tools installed. This is useful if you want to build the
 images without installing the tools on your local machine.
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ Building images requires the following tools:
 - Python 3 with pyyaml (`pip install pyyaml`) for fetching artifacts via the
   `fetch-artifacts.py` script
 
+Alternatively, you can use the provided `Vagrantfile` to create a Virtualbox VM
+with all the required tools installed. This is useful if you want to build the
+images without installing the tools on your local machine.
+
 ### Nexus authentication
 
 Configuring the authentication to Alfresco Nexus server requires setting up


### PR DESCRIPTION
### Description

Add a reference to vagrant into the main readme

### Related Issue

OPSEXP-3247

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have updated the documentation accordingly.
