### PR TITLE
OPSEXP-3247 Improve customization documentation to cover simple jars and share image

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,20 +124,23 @@ specific folders:
 
 - Alfresco Module Packages (AMPs) files in the [amps](repository/amps/README.md)
   folder for both Enterprise and Community editions
-  - For Enterprise-only AMPs files in the [amps-enterprise](repository/amps_enterprise/README.md)
-    folder
-  - For Community-only AMPs files in the [amps-community](repository/amps_community/README.md)
-    folder
-- Simple Module (JAR) files in the [simple_modules](repository/simple_modules/README.md)
+  - For Enterprise-only AMPs files in the
+    [amps-enterprise](repository/amps_enterprise/README.md) folder
+  - For Community-only AMPs files in the
+    [amps-community](repository/amps_community/README.md) folder
+- Simple Module (JAR) files in the
+  [simple_modules](repository/simple_modules/README.md) folder
+- Additional JAR files for the JRE in the [libs](repository/libs/README.md)
   folder
-- Additional JAR files for the JRE in the [libs](repository/libs/README.md) folder
 
 ### Customizing the Share image
 
 The Share image can be customized by adding files into specific folders:
 
-- Alfresco Module Packages (AMPs) files in the [amps](share/amps/README.md) folder
-- Share Simple Module (JAR) files in the [simple_modules](share/simple_modules/README.md)
+- Alfresco Module Packages (AMPs) files in the [amps](share/amps/README.md)
+  folder
+- Share Simple Module (JAR) files in the
+  [simple_modules](share/simple_modules/README.md) folder
 
 ## Supported Architectures
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Bake](https://docs.docker.com/build/bake/).
   - [Getting started quickly](#getting-started-quickly)
   - [Customizing the images](#customizing-the-images)
     - [Customizing the Alfresco Content Repository image](#customizing-the-alfresco-content-repository-image)
+    - [Customizing the Share image](#customizing-the-share-image)
   - [Supported Architectures](#supported-architectures)
     - [Targeting a specific architecture](#targeting-a-specific-architecture)
     - [Multi-arch images](#multi-arch-images)
@@ -118,16 +119,25 @@ make all
 
 ### Customizing the Alfresco Content Repository image
 
-The Alfresco Content Repository image can be customized by adding different
-types of files in the right locations:
+The Alfresco Content Repository image can be customized by adding files into
+specific folders:
 
 - Alfresco Module Packages (AMPs) files in the [amps](repository/amps/README.md)
+  folder for both Enterprise and Community editions
+  - For Enterprise-only AMPs files in the [amps-enterprise](repository/amps_enterprise/README.md)
+    folder
+  - For Community-only AMPs files in the [amps-community](repository/amps_community/README.md)
+    folder
+- Simple Module (JAR) files in the [simple_modules](repository/simple_modules/README.md)
   folder
-  - Enterprise-only AMPs files in the [amps-enterprise](repository/amps_enterprise/README.md)
-    folder
-  - Community-only AMPs files in the [amps-community](repository/amps_community/README.md)
-    folder
 - Additional JAR files for the JRE in the [libs](repository/libs/README.md) folder
+
+### Customizing the Share image
+
+The Share image can be customized by adding files into specific folders:
+
+- Alfresco Module Packages (AMPs) files in the [amps](share/amps/README.md) folder
+- Share Simple Module (JAR) files in the [simple_modules](share/simple_modules/README.md)
 
 ## Supported Architectures
 

--- a/repository/amps/README.md
+++ b/repository/amps/README.md
@@ -10,11 +10,12 @@ The [in-process Alfresco SDK][sdk] provides a way to build well structured AMPs.
 
 > Note that AMPs are not the recommanded way to extend Alfresco. You should
 > prefer using the Alfresco SDK to build your extensions as JARs even better,
-> use the [out-of-process AlfrescoSDK][oop] to
+> use the [out-of-process Alfresco SDK][oop] to
 > build Docker images with your extensions.
 
-By default the `scripts/fetch-artifacts.py` script will fetch only the default
-AMPs, see [artifacts-23.yaml](../artifacts-23.yaml) for additional information.
+By default the `scripts/fetch-artifacts.py` script will fetch some default AMPs,
+see the `artifacts-NN.yaml` for the version you are building for further
+details.
 
 You can replace those, remove them to keep only the ones you need or add more.
 Be careful though as some AMPs may depend on one another (e.g.

--- a/repository/amps_community/README.md
+++ b/repository/amps_community/README.md
@@ -3,4 +3,4 @@
 Place here your Alfresco module Packages (AMPs) to be installed in the Alfresco
 repository community edition only.
 
-For more information see the [general amps README](../amps/README.md).
+For more information see the main [amps README](../amps/README.md).

--- a/repository/amps_enterprise/README.md
+++ b/repository/amps_enterprise/README.md
@@ -3,4 +3,4 @@
 Place here your Alfresco module Packages (AMPs) to be installed in the Alfresco
 repository enterprise edition only.
 
-For more information see the [general amps README](../amps/README.md).
+For more information see the main [amps README](../amps/README.md).

--- a/repository/libs/README.md
+++ b/repository/libs/README.md
@@ -1,4 +1,4 @@
 # Alfresco Content Repository extra jars
 
-Place here additionnal jar files you want to be depoloyed in Tomcat lib directory.
+Place here additional jar files you want to be deployed in Tomcat lib directory.
 This is a suitable way to add JDBC drivers, for example.

--- a/repository/simple_modules/README.md
+++ b/repository/simple_modules/README.md
@@ -1,8 +1,8 @@
 # Alfresco Content Repository Simple Module (JAR)
 
-Full documentation on Simple Module is here:
-https://support.hyland.com/r/Alfresco/Alfresco-Content-Services/23.4/Alfresco-Content-Services/Develop/Extension-Packaging-Modules/Module-Package-Formats/Alfresco-Module-Package-AMP/Using-the-Module-Management-Tool-MMT/Simple-Module-JAR
+You can read the full documentation about Simple Module in the [Alfresco
+documentation](https://support.hyland.com/search/all?query=simple+module+jars&value-filters=platform_custom~%2522Alfresco%2522&content-lang=en-US).
 
 Copy jar files produced by the [Alfresco
 SDK](https://github.com/Alfresco/alfresco-sdk) into `repository/simple_modules`
-to add Simple Module with alfresco-dockerfiles-bakery.
+to add Simple Module to every built repository image.

--- a/share/amps/README.md
+++ b/share/amps/README.md
@@ -3,22 +3,4 @@
 Place here your Alfresco module Packages (AMPs) to be installed in the Alfresco
 share.
 
-AMP packages should have the `.amp` extension and stick to the Alfresco module
-packaging format as described in the [Alfresco documentation][amp].
-
-The [in-process Alfresco SDK][sdk] provides a way to build well structured AMPs.
-
-> Note that AMPs are not the recommanded way to extend Alfresco. You should
-> prefer using the Alfresco SDK to build your extensions as JARs even better,
-> use the [out-of-process Alfresco SDK][oop] to
-> build Docker images with your extensions.
-
-By default the `scripts/fetch-artifacts.py` script will fetch the following AMPs from the Alfresco Nexus repository:
-
-* alfresco-googledrive-share
-
-You can replace those, remove them to keep only the ones you need or add more.
-
-[sdk]: https://support.hyland.com/r/Alfresco/Alfresco-In-Process-SDK/4.10/Alfresco-In-Process-SDK/Introduction
-[oop]: https://support.hyland.com/r/Alfresco/Alfresco-Content-Services/23.4/Alfresco-Content-Services/Develop/Out-of-Process-Extension-Points/Events-Extension-Point
-[amp]: https://support.hyland.com/r/Alfresco/Alfresco-Content-Services/23.4/Alfresco-Content-Services/Develop/Extension-Packaging-Modules/Module-Package-Formats/Alfresco-Module-Package-AMP
+For more information see the repository [amps README](../../repository/amps/README.md).

--- a/share/simple_modules/README.md
+++ b/share/simple_modules/README.md
@@ -1,8 +1,4 @@
 # Alfresco Share Simple Module (JAR)
 
-Full documentation on Simple Module is here:
-https://support.hyland.com/r/Alfresco/Alfresco-Content-Services/23.4/Alfresco-Content-Services/Develop/Extension-Packaging-Modules/Module-Package-Formats/Alfresco-Module-Package-AMP/Using-the-Module-Management-Tool-MMT/Simple-Module-JAR
-
-Copy jar files produced by the [Alfresco
-SDK](https://github.com/Alfresco/alfresco-sdk) into `share/simple_modules` to
-add Simple Module with alfresco-dockerfiles-bakery.
+For more information see the repository [simple_modules
+README](../../repository/simple_modules/README.md).


### PR DESCRIPTION
### Description

This pull request updates the `README.md` file to improve documentation for customizing Docker images. The updates include adding a new section for customizing the Share image and clarifying the instructions for customizing the Alfresco Content Repository image.

### Documentation Improvements:

* **Added a new section for customizing the Share image**: Introduced a detailed explanation of how to customize the Share image by placing AMPs and JAR files in specific folders. This section mirrors the structure of the Alfresco Content Repository customization section.

* **Clarified instructions for customizing the Alfresco Content Repository image**: Updated the description to specify that files should be added to "specific folders" and adjusted the formatting for better readability.

### Related Issue

OPSEXP-3247

### Checklist

- [x] My code follows the project's coding standards.
- [ ] I have updated the documentation accordingly.
