### PR TITLE
Treat 403 while fetching packages as a soft error

### DIFF
--- a/scripts/fetch_artifacts.py
+++ b/scripts/fetch_artifacts.py
@@ -120,6 +120,9 @@ def do_parse_and_mvn_fetch(file_path):
             if e.code == 401:
                 print("Invalid or missing credentials, skipping...")
                 continue
+            elif e.code == 403:
+                print("Forbidden access, skipping...")
+                continue
             else:
                 # rethrow the exception to exit with failure
                 raise e


### PR DESCRIPTION
### Description

When authenticated but without access to a specific artifact, just continue.

### Related Issue

Fix #184 

### Checklist

- [x] My code follows the project's coding standards.
- [ ] I have updated the documentation accordingly.
