### PR TITLE
OPSEXP-3262 Add support for fetching artifacts by passing glob 

### DIFF
--- a/.github/workflows/acs_reusable_build_and_test.yml
+++ b/.github/workflows/acs_reusable_build_and_test.yml
@@ -46,17 +46,11 @@ jobs:
           key: ${{ runner.os }}-packages-v2-${{ hashFiles(env.HASH_FILES_NAME) }}-${{ inputs.acs_version }}
           path: artifacts_cache/**
 
-      - name: Fetch artifacts from nexus
+      - name: Fetch artifacts with test from nexus
         env:
           ACS_VERSION: ${{ inputs.acs_version }}
         run: |
-          python3 ./scripts/fetch_artifacts.py
-
-      - name: Fetch artifacts for testing
-        env:
-          ACS_VERSION: "${{ inputs.acs_version }}-test"
-        run: |
-          python3 ./scripts/fetch_artifacts.py
+          python3 ./scripts/fetch_artifacts.py "" "**/artifacts-${{ inputs.acs_version }}-test.yaml"
 
       - name: Save packages artifacts
         if: steps.artifacts-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/test-with-bats.yml
+++ b/.github/workflows/test-with-bats.yml
@@ -1,0 +1,24 @@
+name: CI with BATS 🦇
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - uses: mig4/setup-bats@af9a00deb21b5d795cabfeaa8d9060410377686d # v1.2.0
+        with:
+          bats-version: 1.8.0
+
+      - name: 🦇🦇🦇
+        run: bats -r --print-output-on-failure .

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Bake](https://docs.docker.com/build/bake/).
     - [Testing with helm](#testing-with-helm)
     - [Testing with docker compose](#testing-with-docker-compose)
   - [Security scanning](#security-scanning)
+  - [Fetch artifcats script](#fetch-artifact-script)
   - [Release](#release)
 
 ## Prerequisites
@@ -411,6 +412,56 @@ You can also run grype automatically at the end of the build process by setting
 ```sh
 make all GRYPE_ONBUILD=1
 ```
+
+## Fetch artifact script
+
+A Python script to download artifacts from the Alfresco Nexus repository based
+on YAML configuration files.
+
+> We recommend using `make` for local operations on this repository but if you
+> want to only leverage the fetching script here is the explanation
+
+### Usage
+
+```bash
+python3 scripts/fetch_artifacts.py [targets...] [options]
+```
+
+### Arguments
+
+#### Targets (optional)
+You can specify one or more targets:
+
+- **No arguments**: Processes the entire repository
+- **Directory path**: Searches for artifact files in the specified directory
+- **File path**: Processes a specific artifact YAML file
+- **Glob pattern**: Uses wildcards to match multiple files/directories
+
+#### Options
+
+- `--log-level {DEBUG,INFO,WARNING,ERROR}` - Set logging verbosity (default: INFO)
+- `--log-file FILE` - Write logs to a file (in addition to console output)
+
+### Examples
+
+```bash
+python3 scripts/fetch_artifacts.py
+python3 scripts/fetch_artifacts.py repository
+python3 scripts/fetch_artifacts.py repository share aps
+python3 scripts/fetch_artifacts.py "**/artifacts-*-aps.yaml"
+python3 scripts/fetch_artifacts.py repository --log-level DEBUG
+python3 scripts/fetch_artifacts.py repository --log-file download.log
+```
+
+### Environment Variables
+
+- `ACS_VERSION` - Alfresco Content Services version (default: "25")
+- `NEXUS_USERNAME` - Nexus repository username
+- `NEXUS_PASSWORD` - Nexus repository password
+- `MAVEN_FQDN` - Maven repository FQDN (default: "nexus.alfresco.com")
+- `MAVEN_REPO` - Full Maven repository URL
+
+For authentication check out [nexus authentication](#nexus-authentication)
 
 ## Release
 

--- a/README.md
+++ b/README.md
@@ -245,11 +245,10 @@ docker buildx bake repo --set *.output=type=registry,push=true
 
 ## Building APS only
 
-To build only APS images without any ACS components, set the APS version and
-leave ACS version empty:
+To build only APS images without any ACS components, set ACS version to empty:
 
 ```sh
-export ACS_VERSION="" APS_VERSION="25"
+export ACS_VERSION=""
 ```
 
 ## Building older versions

--- a/README.md
+++ b/README.md
@@ -243,14 +243,6 @@ export REGISTRY=myecr.domain.tld REGISTRY_NAMESPACE=myalfrescobuilds TARGETARCH=
 docker buildx bake repo --set *.output=type=registry,push=true
 ```
 
-## Building APS only
-
-To build only APS images without any ACS components, set ACS version to empty:
-
-```sh
-export ACS_VERSION=""
-```
-
 ## Building older versions
 
 Versions of artifacts being downloaded specific to the ACS version are defined

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Bake](https://docs.docker.com/build/bake/).
     - [Testing with helm](#testing-with-helm)
     - [Testing with docker compose](#testing-with-docker-compose)
   - [Security scanning](#security-scanning)
-  - [Fetch artifcats script](#fetch-artifact-script)
+  - [Fetch artifacts script](#fetch-artifacts-script)
   - [Release](#release)
 
 ## Prerequisites
@@ -413,7 +413,7 @@ You can also run grype automatically at the end of the build process by setting
 make all GRYPE_ONBUILD=1
 ```
 
-## Fetch artifact script
+## Fetch artifacts script
 
 A Python script to download artifacts from the Alfresco Nexus repository based
 on YAML configuration files.

--- a/README.md
+++ b/README.md
@@ -432,8 +432,10 @@ python3 scripts/fetch_artifacts.py [targets...] [options]
 #### Targets (optional)
 You can specify one or more targets:
 
-- **No arguments**: Processes the entire repository
+- **No arguments**: Processes the entire repository (only files matching
+  `artifacts-*.yaml`)
 - **Directory path**: Searches for artifact files in the specified directory
+  (only files matching `artifacts-*.yaml` in that directory)
 - **File path**: Processes a specific artifact YAML file
 - **Glob pattern**: Uses wildcards to match multiple files/directories
 

--- a/README.md
+++ b/README.md
@@ -243,6 +243,15 @@ export REGISTRY=myecr.domain.tld REGISTRY_NAMESPACE=myalfrescobuilds TARGETARCH=
 docker buildx bake repo --set *.output=type=registry,push=true
 ```
 
+## Building APS only
+
+To build only APS images without any ACS components, set the APS version and
+leave ACS version empty:
+
+```sh
+export ACS_VERSION="" APS_VERSION="25"
+```
+
 ## Building older versions
 
 Versions of artifacts being downloaded specific to the ACS version are defined

--- a/scripts/fetch_artifacts.py
+++ b/scripts/fetch_artifacts.py
@@ -27,7 +27,6 @@ class ChecksumMismatchError(Exception):
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 TEMP_DIR = tempfile.mkdtemp()
 ACS_VERSION = os.getenv("ACS_VERSION", "25")
-APS_VERSION = os.getenv("APS_VERSION", "25")
 MAVEN_FQDN = os.getenv("MAVEN_FQDN", "nexus.alfresco.com")
 MAVEN_REPO = os.getenv("MAVEN_REPO", f"https://{MAVEN_FQDN}/nexus/repository")
 

--- a/scripts/fetch_artifacts.py
+++ b/scripts/fetch_artifacts.py
@@ -36,7 +36,12 @@ logger = logging.getLogger(__name__)
 
 def setup_logging(log_level=logging.INFO, log_file=None):
     """Setup logging configuration"""
-    log_format = '%(message)s'
+    log_format_debug = '%(asctime)s - %(levelname)s: %(message)s'
+
+    if log_level is logging.DEBUG:
+        log_format = log_format_debug
+    else:
+        log_format = '%(message)s'
 
     logger.handlers.clear()
     logger.setLevel(log_level)
@@ -47,7 +52,7 @@ def setup_logging(log_level=logging.INFO, log_file=None):
 
     if log_file:
         file_handler = logging.FileHandler(log_file)
-        file_handler.setFormatter(logging.Formatter('%(asctime)s - %(levelname)s: %(message)s'))
+        file_handler.setFormatter(logging.Formatter(log_format_debug))
         logger.addHandler(file_handler)
 
     logger.propagate = False
@@ -155,7 +160,7 @@ def do_parse_and_mvn_fetch(file_path):
 
 def arg_is_glob_pattern(arg):
     """
-    Check if the argument is a path (returns True) or a glob pattern (returns False)
+    Check if the argument is a path (returns False) or a glob pattern (returns True)
     """
     if os.path.exists(arg):
         logger.debug(f"Argument '{arg}' is a valid path.")

--- a/scripts/fetch_artifacts.py
+++ b/scripts/fetch_artifacts.py
@@ -2,11 +2,13 @@
 Process artifacts yml files to download the artifacts from the Alfresco Nexus repository
 
 Run this script with:
-python3 scripts/fetch_artifacts.py [<target_subdir>]
+python3 scripts/fetch_artifacts.py [<target_subdir>] [--log-level LEVEL] [--log-file FILE]
 
 The target_subdir is the subdirectory where the artifacts yaml files are located (optional)
 """
 
+import argparse
+import logging
 import netrc
 import os
 import shutil
@@ -30,6 +32,26 @@ ACS_VERSION = os.getenv("ACS_VERSION", "25")
 MAVEN_FQDN = os.getenv("MAVEN_FQDN", "nexus.alfresco.com")
 MAVEN_REPO = os.getenv("MAVEN_REPO", f"https://{MAVEN_FQDN}/nexus/repository")
 
+logger = logging.getLogger(__name__)
+
+def setup_logging(log_level=logging.INFO, log_file=None):
+    """Setup logging configuration"""
+    log_format = '%(message)s'
+
+    logger.handlers.clear()
+    logger.setLevel(log_level)
+
+    console_handler = logging.StreamHandler(sys.stdout)
+    console_handler.setFormatter(logging.Formatter(log_format))
+    logger.addHandler(console_handler)
+
+    if log_file:
+        file_handler = logging.FileHandler(log_file)
+        file_handler.setFormatter(logging.Formatter('%(asctime)s - %(levelname)s: %(message)s'))
+        logger.addHandler(file_handler)
+
+    logger.propagate = False
+
 def get_checksums(artifact_checksum, artifact_url, artifact_file_path):
     """
     Get source checksum that must match and the computed checksum
@@ -43,7 +65,7 @@ def get_checksums(artifact_checksum, artifact_url, artifact_file_path):
             with urllib.request.urlopen(f"{artifact_url}.{checksum_type}") as checksum_response:
                 checksum = checksum_response.read().decode("utf-8").strip()
         except urllib.error.HTTPError as e:
-            print(f"Failed to fetch checksum from {artifact_url}.{checksum_type}: {e}")
+            logger.warning(f"Failed to fetch checksum from {artifact_url}.{checksum_type}: {e}")
             return None, None
     else:
         checksum = artifact_checksum.split(":")[1]
@@ -75,34 +97,33 @@ def do_parse_and_mvn_fetch(file_path):
         artifact_final_path = os.path.join(artifact_path, f"{artifact_name}-{artifact_version}{artifact_ext}")
         artifact_url = f"{artifact_baseurl}/{artifact_group.replace('.', '/')}/{artifact_name}/{artifact_version}/{artifact_name}-{artifact_version}{artifact_ext}"
 
-        # Newline for better readability
-        print()
+        logger.info("")
 
         # Check if the artifact is already present
         if os.path.isfile(artifact_final_path):
-            print(f"Artifact {artifact_name}-{artifact_version} already present.")
+            logger.info(f"Artifact {artifact_name}-{artifact_version} already present.")
             src_checksum, computed_checksum = get_checksums(artifact_checksum, artifact_url, artifact_final_path)
             if not src_checksum and not computed_checksum:
-                print('No valid checksum found, skipping verification...')
+                logger.info('No valid checksum found, skipping verification...')
                 continue
             if src_checksum == computed_checksum:
-                print(f"Checksum matched for {artifact_name}-{artifact_version}{artifact_ext}")
+                logger.info(f"Checksum matched for {artifact_name}-{artifact_version}{artifact_ext}")
                 continue
-            print(f"Checksum mismatch for {artifact_name}-{artifact_version}{artifact_ext}. Re-downloading...")
+            logger.info(f"Checksum mismatch for {artifact_name}-{artifact_version}{artifact_ext}. Re-downloading...")
             os.remove(artifact_final_path)
 
         if os.path.isfile(artifact_cache_path):
             src_checksum, computed_checksum = get_checksums(artifact_checksum, artifact_url, artifact_cache_path)
             if src_checksum == computed_checksum:
-                print(f"Artifact {artifact_name}-{artifact_version} already present in cache, copying...")
+                logger.info(f"Artifact {artifact_name}-{artifact_version} already present in cache, copying...")
                 shutil.copy(artifact_cache_path, artifact_final_path)
                 continue
             else:
-                print(f"Checksum mismatch for {artifact_name}-{artifact_version}{artifact_ext}. Re-downloading...")
+                logger.info(f"Checksum mismatch for {artifact_name}-{artifact_version}{artifact_ext}. Re-downloading...")
                 os.remove(artifact_cache_path)
 
         # Download the artifact
-        print(f"Downloading {artifact_group}:{artifact_name} {artifact_version} from {artifact_baseurl}")
+        logger.info(f"Downloading {artifact_group}:{artifact_name} {artifact_version} from {artifact_baseurl}")
         try:
             with urllib.request.urlopen(artifact_url) as response, open(artifact_tmp_path, 'wb') as out_file:
                 shutil.copyfileobj(response, out_file)
@@ -119,10 +140,10 @@ def do_parse_and_mvn_fetch(file_path):
 
         except urllib.error.HTTPError as e:
             if e.code == 401:
-                print("Invalid or missing credentials, skipping...")
+                logger.warning("Invalid or missing credentials, skipping...")
                 continue
             elif e.code == 403:
-                print("Forbidden access, skipping...")
+                logger.warning("Forbidden access, skipping...")
                 continue
             else:
                 # rethrow the exception to exit with failure
@@ -132,31 +153,30 @@ def do_parse_and_mvn_fetch(file_path):
         shutil.move(artifact_tmp_path, artifact_cache_path)
         shutil.copy(artifact_cache_path, artifact_final_path)
 
-def check_if_arg_is_path_or_glob(arg):
+def arg_is_glob_pattern(arg):
     """
     Check if the argument is a path (returns True) or a glob pattern (returns False)
     """
     if os.path.exists(arg):
-        print(f"Argument '{arg}' is a valid path.")
-        return True  # It's a path
+        logger.debug(f"Argument '{arg}' is a valid path.")
+        return False
     elif "*" in arg or "?" in arg:
-        print(f"Argument '{arg}' is a glob pattern.")
-        return False  # It's a glob pattern
+        logger.debug(f"Argument '{arg}' is a glob pattern.")
+        return True
     else:
-        return False  # Not a valid path or glob pattern
+        return False
 
 def find_targets(arg):
     """
     Find all the artifacts yaml files from the given argument which can be a path or a glob pattern
     """
-    if check_if_arg_is_path_or_glob(arg):
+    if arg_is_glob_pattern(arg):
+        return glob.glob(arg, recursive=True)
+    else:
         if os.path.isdir(arg):
             return glob.glob(os.path.join(arg, f"**/artifacts-{ACS_VERSION}.yaml"), recursive=True)
         else:
             return [arg]
-    else:
-        # If it's a glob pattern, use glob to find matching files
-        return glob.glob(arg, recursive=True)
 
 def setup_basic_auth(username, password):
     """
@@ -182,7 +202,7 @@ def get_credentials_from_netrc(machine):
         # Ignore if .netrc file is not found
         pass
     except netrc.NetrcParseError as e:
-        print(f"Error parsing .netrc file: {e}")
+        logger.error(f"Error parsing .netrc file: {e}")
     return None, None
 
 def main(target_subdir=""):
@@ -194,7 +214,19 @@ def main(target_subdir=""):
     for target_file in targets:
         do_parse_and_mvn_fetch(target_file)
 
+def parse_arguments():
+    """Parse command line arguments"""
+    parser = argparse.ArgumentParser(description="Download artifacts from Alfresco Nexus repository")
+    parser.add_argument('targets', nargs='*', help='Target directories or patterns')
+    parser.add_argument('--log-level', choices=['DEBUG', 'INFO', 'WARNING', 'ERROR'], default='INFO', help='Set logging level')
+    parser.add_argument('--log-file', help='Log to file')
+    return parser.parse_args()
+
 if __name__ == "__main__":
+    args = parse_arguments()
+    log_level = getattr(logging, args.log_level.upper())
+    setup_logging(log_level, args.log_file)
+
     username, password = get_credentials_from_netrc('nexus.alfresco.com')
     if os.getenv('NEXUS_USERNAME') and os.getenv('NEXUS_PASSWORD'):
         username = os.getenv('NEXUS_USERNAME')
@@ -203,10 +235,9 @@ if __name__ == "__main__":
         setup_basic_auth(username, password)
 
     # If no arguments provided, run with empty string (default behavior)
-    if len(sys.argv) == 1:
+    if not args.targets:
         main("")
     else:
-        # Process each argument separately
-        for target_directory in sys.argv[1:]:
-            print(f"\n--- Processing target: {target_directory} ---")
+        for target_directory in args.targets:
+            logger.debug(f"--- Processing target: {target_directory} ---")
             main(target_directory)

--- a/scripts/fetch_artifacts.py
+++ b/scripts/fetch_artifacts.py
@@ -234,7 +234,6 @@ if __name__ == "__main__":
     if username and password:
         setup_basic_auth(username, password)
 
-    # If no arguments provided, run with empty string (default behavior)
     if not args.targets:
         main("")
     else:

--- a/scripts/fetch_artifacts.py
+++ b/scripts/fetch_artifacts.py
@@ -26,6 +26,7 @@ class ChecksumMismatchError(Exception):
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 TEMP_DIR = tempfile.mkdtemp()
 ACS_VERSION = os.getenv("ACS_VERSION", "25")
+APS_VERSION = os.getenv("APS_VERSION")
 MAVEN_FQDN = os.getenv("MAVEN_FQDN", "nexus.alfresco.com")
 MAVEN_REPO = os.getenv("MAVEN_REPO", f"https://{MAVEN_FQDN}/nexus/repository")
 
@@ -135,12 +136,29 @@ def find_targets_recursively(root_path):
     """
     Find all the artifacts yaml files from the root path recursively which match the given pattern
     """
-    pattern = f"artifacts-{ACS_VERSION}.yaml"
+    patterns = []
+
+    # Add ACS pattern if ACS_VERSION is provided and not empty
+    if ACS_VERSION and ACS_VERSION != "null":
+        acs_pattern = f"artifacts-{ACS_VERSION}.yaml"
+        patterns.append(acs_pattern)
+
+    # Add APS pattern if APS_VERSION is provided and not empty
+    if APS_VERSION and APS_VERSION != "null":
+        aps_pattern = f"artifacts-{APS_VERSION}-aps.yaml"
+        patterns.append(aps_pattern)
+
+    # If no patterns are defined, warn the user
+    if not patterns:
+        print("Warning: Neither ACS_VERSION nor APS_VERSION is provided. No artifacts will be downloaded.")
+        return []
+
     targets = []
     for root, _, files in os.walk(root_path):
         for file in files:
-            if file == pattern:
+            if file in patterns:
                 targets.append(os.path.join(root, file))
+
     return targets
 
 def setup_basic_auth(username, password):

--- a/scripts/fetch_artifacts.py
+++ b/scripts/fetch_artifacts.py
@@ -26,7 +26,7 @@ class ChecksumMismatchError(Exception):
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 TEMP_DIR = tempfile.mkdtemp()
 ACS_VERSION = os.getenv("ACS_VERSION", "25")
-APS_VERSION = os.getenv("APS_VERSION")
+APS_VERSION = os.getenv("APS_VERSION", "25")
 MAVEN_FQDN = os.getenv("MAVEN_FQDN", "nexus.alfresco.com")
 MAVEN_REPO = os.getenv("MAVEN_REPO", f"https://{MAVEN_FQDN}/nexus/repository")
 

--- a/scripts/fetch_artifacts.py
+++ b/scripts/fetch_artifacts.py
@@ -134,7 +134,7 @@ def do_parse_and_mvn_fetch(file_path):
 
 def check_if_arg_is_path_or_glob(arg):
     """
-    Check if the argument is a path or a glob pattern
+    Check if the argument is a path (returns True) or a glob pattern (returns False)
     """
     if os.path.exists(arg):
         print(f"Argument '{arg}' is a valid path.")

--- a/scripts/tests/test_fetch_artifacts.bats
+++ b/scripts/tests/test_fetch_artifacts.bats
@@ -1,5 +1,4 @@
 #!/usr/bin/env bats
-# filepath: /Users/pawel.maciusiak/Documents/alfresco-dockerfiles/scripts/tests/test_fetch_artifacts.bats
 
 setup() {
     export SCRIPT_DIR="$BATS_TEST_DIRNAME/.."

--- a/scripts/tests/test_fetch_artifacts.bats
+++ b/scripts/tests/test_fetch_artifacts.bats
@@ -31,7 +31,7 @@ teardown() {
     export ACS_VERSION=""
 
     cd "$ACTUAL_REPO_ROOT"
-    run python3 scripts/fetch_artifacts.py 2>&1
+    run python3 scripts/fetch_artifacts.py --log-level DEBUG 2>&1
     echo "Output: $output"
 
     # Should not crash

--- a/scripts/tests/test_fetch_artifacts.bats
+++ b/scripts/tests/test_fetch_artifacts.bats
@@ -1,13 +1,26 @@
 #!/usr/bin/env bats
+# filepath: /Users/pawel.maciusiak/Documents/alfresco-dockerfiles/scripts/tests/test_fetch_artifacts.bats
 
 setup() {
-    export TEST_DIR=$(mktemp -d)
     export SCRIPT_DIR="$BATS_TEST_DIRNAME/.."
     export FETCH_SCRIPT="$SCRIPT_DIR/fetch_artifacts.py"
+    export ACTUAL_REPO_ROOT="$SCRIPT_DIR/.."
+
+    # Create temporary test directories in the actual repo structure
+    export TEST_REPO1="$ACTUAL_REPO_ROOT/test_repo1"
+    export TEST_REPO2="$ACTUAL_REPO_ROOT/test_repo2"
+    export TEST_EXISTING_DIR="$ACTUAL_REPO_ROOT/test_existing_dir"
 }
 
 teardown() {
-    rm -rf "$TEST_DIR"
+    # Clean up test directories from actual repo
+    rm -rf "$TEST_REPO1" "$TEST_REPO2" "$TEST_EXISTING_DIR"
+    rm -rf "$ACTUAL_REPO_ROOT/bats_test"
+}
+
+@test "script exists and is executable" {
+    [ -f "$FETCH_SCRIPT" ]
+    [ -r "$FETCH_SCRIPT" ]
 }
 
 @test "script runs without crashing" {
@@ -20,7 +33,8 @@ teardown() {
     export ACS_VERSION=""
     export APS_VERSION=""
 
-    run timeout 5 python3 "$FETCH_SCRIPT" 2>&1 || true
+    cd "$ACTUAL_REPO_ROOT"
+    run timeout 5 python3 scripts/fetch_artifacts.py 2>&1 || true
     echo "Output: $output"
 
     # Should not crash
@@ -30,11 +44,11 @@ teardown() {
 @test "script detects ACS version from environment" {
     export ACS_VERSION="25"
 
-    # Create test directory structure
-    mkdir -p "$TEST_DIR/repository"
+    # Create test directory structure in actual repo
+    mkdir -p "$TEST_REPO1"
 
     # Create minimal artifact file
-    cat > "$TEST_DIR/repository/artifacts-25.yaml" << 'EOF'
+    cat > "$TEST_REPO1/artifacts-25.yaml" << 'EOF'
 artifacts:
   test-artifact:
     name: test-artifact
@@ -42,71 +56,128 @@ artifacts:
     classifier: .jar
     repository: public
     group: com.test
-    path: repository
+    path: test_repo1
 EOF
 
-    cd "$TEST_DIR"
-    run timeout 10 python3 "$FETCH_SCRIPT" repository 2>&1 || true
+    cd "$ACTUAL_REPO_ROOT"
+    run timeout 10 python3 scripts/fetch_artifacts.py test_repo1 2>&1 || true
     echo "Output: $output"
 
-    # Should attempt to process the file
-    [[ "$output" == *"Processing target: repository"* ]] || [[ "$output" == *"test-artifact"* ]]
+    # Should detect as valid path and process
+    [[ "$output" == *"Processing target: test_repo1"* ]] && [[ "$output" == *"valid path"* ]]
 }
 
 @test "script handles multiple arguments" {
     export ACS_VERSION="25"
 
-    mkdir -p "$TEST_DIR/repo1" "$TEST_DIR/repo2"
+    # Create test directories in actual repo structure
+    mkdir -p "$TEST_REPO1" "$TEST_REPO2"
 
-    cat > "$TEST_DIR/repo1/artifacts-25.yaml" << 'EOF'
+    cat > "$TEST_REPO1/artifacts-25.yaml" << 'EOF'
 artifacts: {}
 EOF
 
-    cat > "$TEST_DIR/repo2/artifacts-25.yaml" << 'EOF'
+    cat > "$TEST_REPO2/artifacts-25.yaml" << 'EOF'
 artifacts: {}
 EOF
 
-    cd "$TEST_DIR"
-    run timeout 10 python3 "$FETCH_SCRIPT" repo1 repo2 2>&1 || true
+    cd "$ACTUAL_REPO_ROOT"
+    run timeout 10 python3 scripts/fetch_artifacts.py test_repo1 test_repo2 2>&1 || true
     echo "Output: $output"
 
-    [[ "$output" == *"Processing target: repo1"* ]]
-    [[ "$output" == *"Processing target: repo2"* ]]
+    # Should show BOTH "Processing target" AND "valid path" messages for each
+    [[ "$output" == *"Processing target: test_repo1"* ]] && [[ "$output" == *"valid path"* ]]
+    [[ "$output" == *"Processing target: test_repo2"* ]] && [[ "$output" == *"valid path"* ]]
+}
+
+@test "script detects valid paths vs glob patterns" {
+    export ACS_VERSION="25"
+
+    # Create directory in actual repo structure
+    mkdir -p "$TEST_EXISTING_DIR"
+
+    cd "$ACTUAL_REPO_ROOT"
+
+    # Test with existing directory (should be detected as valid path)
+    run timeout 10 python3 scripts/fetch_artifacts.py test_existing_dir 2>&1 || true
+    echo "Valid path test output: $output"
+
+    # Should show BOTH "Processing target" AND "valid path"
+    [[ "$output" == *"Processing target: test_existing_dir"* ]] && [[ "$output" == *"valid path"* ]]
+
+    # Test with glob pattern (should be detected as glob)
+    run timeout 10 python3 scripts/fetch_artifacts.py "**/nonexistent-*.yaml" 2>&1 || true
+    echo "Glob pattern test output: $output"
+
+    # Should detect as glob pattern
+    [[ "$output" == *"glob pattern"* ]]
 }
 
 @test "script handles glob patterns" {
     export ACS_VERSION="25"
 
-    mkdir -p "$TEST_DIR/test/subdir"
+    # Create nested structure in actual repo
+    mkdir -p "$ACTUAL_REPO_ROOT/bats_test/subdir"
 
-    cat > "$TEST_DIR/test/subdir/artifacts-25.yaml" << 'EOF'
+    cat > "$ACTUAL_REPO_ROOT/bats_test/subdir/artifacts-25-uncommon.yaml" << 'EOF'
 artifacts: {}
 EOF
 
-    cd "$TEST_DIR"
-    run timeout 10 python3 "$FETCH_SCRIPT" "test/**/artifacts-*.yaml" 2>&1 || true
+    cd "$ACTUAL_REPO_ROOT"
+    run timeout 10 python3 scripts/fetch_artifacts.py "**/artifacts-*-uncommon.yaml" 2>&1 || true
     echo "Output: $output"
 
-    [[ "$output" == *"Processing target: test/**/artifacts-*.yaml"* ]]
+    # The glob pattern should be detected
+    [[ "$output" == *"glob pattern"* ]]
 }
 
+@test "script handles invalid paths gracefully" {
+    export ACS_VERSION="25"
+
+    cd "$ACTUAL_REPO_ROOT"
+    run timeout 10 python3 scripts/fetch_artifacts.py nonexistent_directory_12345 2>&1 || true
+    echo "Output: $output"
+    echo "Status: $status"
+
+    # Should handle non-existent paths gracefully (returns False from check function)
+    [[ "$output" != *"Traceback"* ]]
+}
 
 @test "script handles completely broken YAML" {
     export ACS_VERSION="25"
 
-    mkdir -p "$TEST_DIR/test"
+    # Create test directory in actual repo
+    mkdir -p "$ACTUAL_REPO_ROOT/bats_test"
 
     # Create completely invalid YAML
-    cat > "$TEST_DIR/test/artifacts-25.yaml" << 'EOF'
+    cat > "$ACTUAL_REPO_ROOT/bats_test/artifacts-25.yaml" << 'EOF'
 this is not yaml at all!!!
 random text [[[
 EOF
 
-    cd "$TEST_DIR"
-    run timeout 10 python3 "$FETCH_SCRIPT" test 2>&1 || true
+    cd "$ACTUAL_REPO_ROOT"
+    run timeout 10 python3 scripts/fetch_artifacts.py test 2>&1 || true
     echo "Output: $output"
     echo "Status: $status"
 
-    # Should handle the error gracefully
+    # Should detect test as valid path and handle YAML error gracefully
+    [[ "$output" == *"valid path"* ]] && [[ "$output" == *"Processing target: test"* ]]
     [[ "$status" -ne 0 ]] || [[ "$output" != *"Traceback"* ]]
+}
+
+@test "script works with existing repo directories" {
+    export ACS_VERSION="25"
+
+    cd "$ACTUAL_REPO_ROOT"
+
+    # Test with existing directories that should be in the repo
+    # Use repository directory if it exists
+    if [ -d "repository" ]; then
+        run timeout 10 python3 scripts/fetch_artifacts.py repository 2>&1 || true
+        echo "Output: $output"
+
+        [[ "$output" == *"Processing target: repository"* ]] && [[ "$output" == *"valid path"* ]]
+    else
+        skip "repository directory not found in repo"
+    fi
 }

--- a/scripts/tests/test_fetch_artifacts.bats
+++ b/scripts/tests/test_fetch_artifacts.bats
@@ -1,0 +1,113 @@
+#!/usr/bin/env bats
+# filepath: /Users/pawel.maciusiak/Documents/alfresco-dockerfiles/tests/test_fetch_artifacts.bats
+
+setup() {
+    export TEST_DIR=$(mktemp -d)
+    export SCRIPT_DIR="$BATS_TEST_DIRNAME/.."
+    export FETCH_SCRIPT="$SCRIPT_DIR/fetch_artifacts.py"
+}
+
+teardown() {
+    rm -rf "$TEST_DIR"
+}
+
+@test "script runs without crashing" {
+    run python3 "$FETCH_SCRIPT" --help 2>/dev/null || true
+    # Should not contain Python traceback
+    [[ "$output" != *"Traceback"* ]]
+}
+
+@test "script handles no arguments" {
+    export ACS_VERSION=""
+    export APS_VERSION=""
+
+    run timeout 5 python3 "$FETCH_SCRIPT" 2>&1 || true
+    echo "Output: $output"
+
+    # Should not crash
+    [[ "$output" != *"Traceback"* ]]
+}
+
+@test "script detects ACS version from environment" {
+    export ACS_VERSION="25"
+
+    # Create test directory structure
+    mkdir -p "$TEST_DIR/repository"
+
+    # Create minimal artifact file
+    cat > "$TEST_DIR/repository/artifacts-25.yaml" << 'EOF'
+artifacts:
+  test-artifact:
+    name: test-artifact
+    version: 1.0.0
+    classifier: .jar
+    repository: public
+    group: com.test
+    path: repository
+EOF
+
+    cd "$TEST_DIR"
+    run timeout 10 python3 "$FETCH_SCRIPT" repository 2>&1 || true
+    echo "Output: $output"
+
+    # Should attempt to process the file
+    [[ "$output" == *"Processing target: repository"* ]] || [[ "$output" == *"test-artifact"* ]]
+}
+
+@test "script handles multiple arguments" {
+    export ACS_VERSION="25"
+
+    mkdir -p "$TEST_DIR/repo1" "$TEST_DIR/repo2"
+
+    cat > "$TEST_DIR/repo1/artifacts-25.yaml" << 'EOF'
+artifacts: {}
+EOF
+
+    cat > "$TEST_DIR/repo2/artifacts-25.yaml" << 'EOF'
+artifacts: {}
+EOF
+
+    cd "$TEST_DIR"
+    run timeout 10 python3 "$FETCH_SCRIPT" repo1 repo2 2>&1 || true
+    echo "Output: $output"
+
+    [[ "$output" == *"Processing target: repo1"* ]]
+    [[ "$output" == *"Processing target: repo2"* ]]
+}
+
+@test "script handles glob patterns" {
+    export ACS_VERSION="25"
+
+    mkdir -p "$TEST_DIR/test/subdir"
+
+    cat > "$TEST_DIR/test/subdir/artifacts-25.yaml" << 'EOF'
+artifacts: {}
+EOF
+
+    cd "$TEST_DIR"
+    run timeout 10 python3 "$FETCH_SCRIPT" "test/**/artifacts-*.yaml" 2>&1 || true
+    echo "Output: $output"
+
+    [[ "$output" == *"Processing target: test/**/artifacts-*.yaml"* ]]
+}
+
+
+@test "script handles completely broken YAML" {
+    export ACS_VERSION="25"
+
+    mkdir -p "$TEST_DIR/test"
+
+    # Create completely invalid YAML
+    cat > "$TEST_DIR/test/artifacts-25.yaml" << 'EOF'
+this is not yaml at all!!!
+random text [[[
+EOF
+
+    cd "$TEST_DIR"
+    run timeout 10 python3 "$FETCH_SCRIPT" test 2>&1 || true
+    echo "Output: $output"
+    echo "Status: $status"
+
+    # Should handle the error gracefully
+    [[ "$status" -ne 0 ]] || [[ "$output" != *"Traceback"* ]]
+}

--- a/scripts/tests/test_fetch_artifacts.bats
+++ b/scripts/tests/test_fetch_artifacts.bats
@@ -30,7 +30,6 @@ teardown() {
 
 @test "script handles no arguments" {
     export ACS_VERSION=""
-    export APS_VERSION=""
 
     cd "$ACTUAL_REPO_ROOT"
     run timeout 5 python3 scripts/fetch_artifacts.py 2>&1 || true

--- a/scripts/tests/test_fetch_artifacts.bats
+++ b/scripts/tests/test_fetch_artifacts.bats
@@ -163,20 +163,3 @@ EOF
     [[ "$output" == *"valid path"* ]] && [[ "$output" == *"Processing target: test"* ]]
     [[ "$status" -ne 0 ]] || [[ "$output" != *"Traceback"* ]]
 }
-
-@test "script works with existing repo directories" {
-    export ACS_VERSION="25"
-
-    cd "$ACTUAL_REPO_ROOT"
-
-    # Test with existing directories that should be in the repo
-    # Use repository directory if it exists
-    if [ -d "repository" ]; then
-        run timeout 10 python3 scripts/fetch_artifacts.py repository 2>&1 || true
-        echo "Output: $output"
-
-        [[ "$output" == *"Processing target: repository"* ]] && [[ "$output" == *"valid path"* ]]
-    else
-        skip "repository directory not found in repo"
-    fi
-}

--- a/scripts/tests/test_fetch_artifacts.bats
+++ b/scripts/tests/test_fetch_artifacts.bats
@@ -1,5 +1,4 @@
 #!/usr/bin/env bats
-# filepath: /Users/pawel.maciusiak/Documents/alfresco-dockerfiles/tests/test_fetch_artifacts.bats
 
 setup() {
     export TEST_DIR=$(mktemp -d)

--- a/scripts/tests/test_fetch_artifacts.bats
+++ b/scripts/tests/test_fetch_artifacts.bats
@@ -23,7 +23,7 @@ teardown() {
 }
 
 @test "script runs without crashing" {
-    run python3 "$FETCH_SCRIPT" --help 2>/dev/null
+    run python3 "$FETCH_SCRIPT" --help
     [[ "$output" != *"Traceback"* ]]
 }
 

--- a/scripts/tests/test_fetch_artifacts.bats
+++ b/scripts/tests/test_fetch_artifacts.bats
@@ -58,7 +58,7 @@ artifacts:
 EOF
 
     cd "$ACTUAL_REPO_ROOT"
-    run timeout 10 python3 scripts/fetch_artifacts.py test_repo1 2>&1 || true
+    run timeout 10 python3 scripts/fetch_artifacts.py --log-level DEBUG test_repo1 2>&1 || true
     echo "Output: $output"
 
     # Should detect as valid path and process
@@ -80,7 +80,7 @@ artifacts: {}
 EOF
 
     cd "$ACTUAL_REPO_ROOT"
-    run timeout 10 python3 scripts/fetch_artifacts.py test_repo1 test_repo2 2>&1 || true
+    run timeout 10 python3 scripts/fetch_artifacts.py --log-level DEBUG test_repo1 test_repo2 2>&1 || true
     echo "Output: $output"
 
     # Should show BOTH "Processing target" AND "valid path" messages for each
@@ -97,14 +97,14 @@ EOF
     cd "$ACTUAL_REPO_ROOT"
 
     # Test with existing directory (should be detected as valid path)
-    run timeout 10 python3 scripts/fetch_artifacts.py test_existing_dir 2>&1 || true
+    run timeout 10 python3 scripts/fetch_artifacts.py test_existing_dir --log-level DEBUG  2>&1 || true
     echo "Valid path test output: $output"
 
     # Should show BOTH "Processing target" AND "valid path"
     [[ "$output" == *"Processing target: test_existing_dir"* ]] && [[ "$output" == *"valid path"* ]]
 
     # Test with glob pattern (should be detected as glob)
-    run timeout 10 python3 scripts/fetch_artifacts.py "**/nonexistent-*.yaml" 2>&1 || true
+    run timeout 10 python3 scripts/fetch_artifacts.py "**/nonexistent-*.yaml" --log-level DEBUG 2>&1 || true
     echo "Glob pattern test output: $output"
 
     # Should detect as glob pattern
@@ -122,23 +122,11 @@ artifacts: {}
 EOF
 
     cd "$ACTUAL_REPO_ROOT"
-    run timeout 10 python3 scripts/fetch_artifacts.py "**/artifacts-*-uncommon.yaml" 2>&1 || true
+    run timeout 10 python3 scripts/fetch_artifacts.py "**/artifacts-*-uncommon.yaml" --log-level DEBUG 2>&1 || true
     echo "Output: $output"
 
     # The glob pattern should be detected
     [[ "$output" == *"glob pattern"* ]]
-}
-
-@test "script handles invalid paths gracefully" {
-    export ACS_VERSION="25"
-
-    cd "$ACTUAL_REPO_ROOT"
-    run timeout 10 python3 scripts/fetch_artifacts.py nonexistent_directory_12345 2>&1 || true
-    echo "Output: $output"
-    echo "Status: $status"
-
-    # Should handle non-existent paths gracefully (returns False from check function)
-    [[ "$output" != *"Traceback"* ]]
 }
 
 @test "script handles completely broken YAML" {
@@ -154,7 +142,7 @@ random text [[[
 EOF
 
     cd "$ACTUAL_REPO_ROOT"
-    run timeout 10 python3 scripts/fetch_artifacts.py test 2>&1 || true
+    run timeout 10 python3 scripts/fetch_artifacts.py test 2>&1 --log-level DEBUG || true
     echo "Output: $output"
     echo "Status: $status"
 

--- a/scripts/tests/test_fetch_artifacts.bats
+++ b/scripts/tests/test_fetch_artifacts.bats
@@ -31,7 +31,7 @@ teardown() {
     export ACS_VERSION=""
 
     cd "$ACTUAL_REPO_ROOT"
-    run python3 scripts/fetch_artifacts.py --log-level DEBUG 2>&1
+    run python3 scripts/fetch_artifacts.py --log-level DEBUG
     echo "Output: $output"
 
     # Should not crash
@@ -59,7 +59,7 @@ artifacts:
 EOF
 
     cd "$ACTUAL_REPO_ROOT"
-    run python3 scripts/fetch_artifacts.py --log-level DEBUG test_repo1 2>&1
+    run python3 scripts/fetch_artifacts.py --log-level DEBUG test_repo1
     echo "Output: $output"
 
     # Should detect as valid path and process
@@ -83,7 +83,7 @@ artifacts: {}
 EOF
 
     cd "$ACTUAL_REPO_ROOT"
-    run python3 scripts/fetch_artifacts.py --log-level DEBUG test_repo1 test_repo2 2>&1
+    run python3 scripts/fetch_artifacts.py --log-level DEBUG test_repo1 test_repo2
     echo "Output: $output"
 
     # Should show BOTH "Processing target" AND "valid path" messages for each
@@ -102,7 +102,7 @@ EOF
     cd "$ACTUAL_REPO_ROOT"
 
     # Test with existing directory (should be detected as valid path)
-    run python3 scripts/fetch_artifacts.py test_existing_dir --log-level DEBUG  2>&1
+    run python3 scripts/fetch_artifacts.py test_existing_dir --log-level DEBUG
     echo "Valid path test output: $output"
 
     # Should show BOTH "Processing target" AND "valid path"
@@ -111,7 +111,7 @@ EOF
     [[ "$output" != *"ERROR:"* ]]
 
     # Test with glob pattern (should be detected as glob)
-    run python3 scripts/fetch_artifacts.py "**/nonexistent-*.yaml" --log-level DEBUG 2>&1
+    run python3 scripts/fetch_artifacts.py "**/nonexistent-*.yaml" --log-level DEBUG
     echo "Glob pattern test output: $output"
 
     # Should detect as glob pattern
@@ -131,7 +131,7 @@ artifacts: {}
 EOF
 
     cd "$ACTUAL_REPO_ROOT"
-    run python3 scripts/fetch_artifacts.py "**/artifacts-*-uncommon.yaml" --log-level DEBUG 2>&1
+    run python3 scripts/fetch_artifacts.py "**/artifacts-*-uncommon.yaml" --log-level DEBUG
     echo "Output: $output"
 
     # The glob pattern should be detected
@@ -153,7 +153,7 @@ random text [[[
 EOF
 
     cd "$ACTUAL_REPO_ROOT"
-    run python3 scripts/fetch_artifacts.py test 2>&1 --log-level DEBUG
+    run python3 scripts/fetch_artifacts.py test --log-level DEBUG
     echo "Output: $output"
     echo "Status: $status"
 


### PR DESCRIPTION
### Description

This PR adds support for fetching artifacts using glob patterns while refactoring the target file discovery logic. Key changes include the introduction of a new function to differentiate between path and glob input, the refactoring of the artifact-finding logic in the main script, and the addition of extensive tests (using BATS) to validate various scenarios.

### Related Issue

OPSEXP-3262

### Checklist

- [ ] My code follows the project's coding standards.
- [ ] I have updated the documentation accordingly.
