### PR TITLE
OPSEXP-3262 Make reusable workflow out of bake build

### DIFF
--- a/.github/workflows/acs_reusable_build_and_test.yml
+++ b/.github/workflows/acs_reusable_build_and_test.yml
@@ -19,6 +19,7 @@ env:
 
 jobs:
   build:
+    if: github.actor != 'dependabot[bot]'
     uses: ./.github/workflows/reusable_bake_build.yml
     with:
       version: ${{ inputs.acs_version }}

--- a/.github/workflows/reusable_bake_build.yml
+++ b/.github/workflows/reusable_bake_build.yml
@@ -17,7 +17,7 @@ on:
         required: true
         type: string
       artifacts-to-fetch:
-        description: "List of artifacts to fetch from Nexus"
+        description: "A glob pattern to fetch artifacts from Nexus, also used for caching"
         required: true
         type: string
 
@@ -28,7 +28,6 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: github.actor != 'dependabot[bot]'
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
### Description

Make reusable workflow out of build job to enable building both aps and acs also to reduce code duplication

### Related Issue

OPSEXP-3262

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have updated the documentation accordingly.
