### PR TITLE
OPSEXP-3262 Add missing env in reusable bake workflow needed by bake file

### DIFF
--- a/.github/workflows/reusable_bake_build.yml
+++ b/.github/workflows/reusable_bake_build.yml
@@ -24,6 +24,7 @@ on:
 env:
   REGISTRY: ghcr.io
   REGISTRY_NAMESPACE: alfresco
+  TAG: ${{ inputs.tag }}
 
 jobs:
   build:


### PR DESCRIPTION

### Description

After moving to reusable workflow I forgot to add also env `TAG` which is used by bake file. Strangely workflow passed without problems.

### Related Issue
OPSEXP-3262
### Checklist

- [ ] My code follows the project's coding standards.
- [ ] I have updated the documentation accordingly.
