### PR TITLE
Fix cleaning script - war file extenstion was missing

### DIFF
--- a/scripts/clean-artifacts.sh
+++ b/scripts/clean-artifacts.sh
@@ -27,7 +27,7 @@ fi
 files=$(
   find $FIND_MAC_OPTS "$REPO_ROOT" $FIND_OPTS \
     ! -path '*/artifacts_cache/*' \
-    -regex ".*-.*\.(jar|zip|amp|tgz|gz|rpm|deb)"
+    -regex ".*-.*\.(jar|zip|amp|tgz|gz|rpm|deb|war)"
 )
 
 if [ -z "$files" ]; then


### PR DESCRIPTION
### Description

After aps PR we forgot to add .war to cleaning script


### Checklist

- [ ] My code follows the project's coding standards.
- [ ] I have updated the documentation accordingly.
