### PR TITLE
OPSEXP-3292 Review usage of stefanzweifel/git-auto-commit-action and bump version to v6

### DIFF
--- a/.github/workflows/bumpVersions.yml
+++ b/.github/workflows/bumpVersions.yml
@@ -75,14 +75,13 @@ jobs:
 
       - name: Git Auto Commit
         if: github.actor != 'dependabot[bot]'
-        uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403 # v5.2.0
+        uses: stefanzweifel/git-auto-commit-action@778341af668090896ca464160c2def5d1d1a3eb0 # v6.0.1
         with:
           commit_message: |
             🛠 Updatecli pipeline artifacts bump
           commit_user_name: ${{ vars.BOT_GITHUB_USERNAME }}
           commit_user_email: ${{ vars.BOT_GITHUB_EMAIL }}
           branch: ${{ github.ref_name == env.DEFAULT_BRANCH_NAME && 'updatecli-bump-versions' || github.ref_name }}
-          create_branch: ${{ github.ref_name == env.DEFAULT_BRANCH_NAME }}
           push_options: ${{ github.ref_name == env.DEFAULT_BRANCH_NAME && '--force' || '' }}
 
   tomcats:

--- a/ats/sfs/artifacts-23.yaml
+++ b/ats/sfs/artifacts-23.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: 23.N
 artifacts:
   alfresco-shared-file-store-controller:
     name: alfresco-shared-file-store-controller
-    version: 4.1.7
+    version: 4.2.0
     classifier: ".jar"
     repository: enterprise-releases
     group: org.alfresco

--- a/ats/sfs/artifacts-25.yaml
+++ b/ats/sfs/artifacts-25.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: current
 artifacts:
   alfresco-shared-file-store-controller:
     name: alfresco-shared-file-store-controller
-    version: 4.1.7
+    version: 4.2.0
     classifier: ".jar"
     repository: enterprise-releases
     group: org.alfresco

--- a/ats/sfs/artifacts-74.yaml
+++ b/ats/sfs/artifacts-74.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: 7.4.N
 artifacts:
   alfresco-shared-file-store-controller:
     name: alfresco-shared-file-store-controller
-    version: 4.1.7
+    version: 4.2.0
     classifier: ".jar"
     repository: enterprise-releases
     group: org.alfresco

--- a/ats/trouter/artifacts-23.yaml
+++ b/ats/trouter/artifacts-23.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: 23.N
 artifacts:
   alfresco-transform-router:
     name: alfresco-transform-router
-    version: 4.1.7
+    version: 4.2.0
     classifier: ".jar"
     repository: enterprise-releases
     group: org.alfresco

--- a/ats/trouter/artifacts-25.yaml
+++ b/ats/trouter/artifacts-25.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: current
 artifacts:
   alfresco-transform-router:
     name: alfresco-transform-router
-    version: 4.1.7
+    version: 4.2.0
     classifier: ".jar"
     repository: enterprise-releases
     group: org.alfresco

--- a/ats/trouter/artifacts-74.yaml
+++ b/ats/trouter/artifacts-74.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: 7.4.N
 artifacts:
   alfresco-transform-router:
     name: alfresco-transform-router
-    version: 4.1.7
+    version: 4.2.0
     classifier: ".jar"
     repository: enterprise-releases
     group: org.alfresco

--- a/connector/ms365/artifacts-23.yaml
+++ b/connector/ms365/artifacts-23.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: 23.N
 artifacts:
   onedrive-springboot:
     name: onedrive-springboot
-    version: 2.0.6
+    version: 2.0.7
     classifier: ".jar"
     repository: enterprise-releases
     group: org.alfresco

--- a/connector/ms365/artifacts-25.yaml
+++ b/connector/ms365/artifacts-25.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: current
 artifacts:
   onedrive-springboot:
     name: onedrive-springboot
-    version: 2.0.6
+    version: 2.0.7
     classifier: ".jar"
     repository: enterprise-releases
     group: org.alfresco

--- a/connector/ms365/artifacts-73.yaml
+++ b/connector/ms365/artifacts-73.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: 7.3.N
 artifacts:
   onedrive-springboot:
     name: onedrive-springboot
-    version: 2.0.6
+    version: 2.0.7
     classifier: ".jar"
     repository: enterprise-releases
     group: org.alfresco

--- a/connector/ms365/artifacts-74.yaml
+++ b/connector/ms365/artifacts-74.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: 7.4.N
 artifacts:
   onedrive-springboot:
     name: onedrive-springboot
-    version: 2.0.6
+    version: 2.0.7
     classifier: ".jar"
     repository: enterprise-releases
     group: org.alfresco

--- a/connector/msteams/artifacts-23.yaml
+++ b/connector/msteams/artifacts-23.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: 23.N
 artifacts:
   alfresco-ms-teams-springboot:
     name: alfresco-ms-teams-springboot
-    version: 2.0.6
+    version: 2.0.7
     classifier: ".jar"
     repository: enterprise-releases
     group: org.alfresco

--- a/connector/msteams/artifacts-25.yaml
+++ b/connector/msteams/artifacts-25.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: current
 artifacts:
   alfresco-ms-teams-springboot:
     name: alfresco-ms-teams-springboot
-    version: 2.0.6
+    version: 2.0.7
     classifier: ".jar"
     repository: enterprise-releases
     group: org.alfresco

--- a/connector/msteams/artifacts-73.yaml
+++ b/connector/msteams/artifacts-73.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: 7.3.N
 artifacts:
   alfresco-ms-teams-springboot:
     name: alfresco-ms-teams-springboot
-    version: 2.0.6
+    version: 2.0.7
     classifier: ".jar"
     repository: enterprise-releases
     group: org.alfresco

--- a/connector/msteams/artifacts-74.yaml
+++ b/connector/msteams/artifacts-74.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: 7.4.N
 artifacts:
   alfresco-ms-teams-springboot:
     name: alfresco-ms-teams-springboot
-    version: 2.0.6
+    version: 2.0.7
     classifier: ".jar"
     repository: enterprise-releases
     group: org.alfresco

--- a/repository/artifacts-23.yaml
+++ b/repository/artifacts-23.yaml
@@ -13,7 +13,7 @@ artifacts:
     checksum: "sha1:"
   alfresco-share-services:
     name: alfresco-share-services
-    version: 23.5.0.19
+    version: 23.5.1.1
     path: repository/amps
     classifier: ".amp"
     group: org.alfresco

--- a/repository/artifacts-25.yaml
+++ b/repository/artifacts-25.yaml
@@ -13,7 +13,7 @@ artifacts:
     checksum: "sha1:"
   alfresco-share-services:
     name: alfresco-share-services
-    version: 25.1.2.1
+    version: 25.1.2.4
     path: repository/amps
     classifier: ".amp"
     group: org.alfresco

--- a/repository/artifacts-73.yaml
+++ b/repository/artifacts-73.yaml
@@ -45,7 +45,7 @@ artifacts:
     checksum: "sha1:"
   alfresco-content-services-distribution:
     name: alfresco-content-services-distribution
-    version: 7.3.2.3
+    version: 7.3.0.9
     path: repository/distribution
     classifier: ".zip"
     group: org.alfresco

--- a/search/enterprise/all-in-one/artifacts-23.yaml
+++ b/search/enterprise/all-in-one/artifacts-23.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: 23.N
 artifacts:
   alfresco-elasticsearch-live-indexing:
     name: alfresco-elasticsearch-live-indexing
-    version: 5.1.0
+    version: 5.1.1
     classifier: "-app.jar"
     repository: enterprise-releases
     group: org.alfresco

--- a/search/enterprise/all-in-one/artifacts-25.yaml
+++ b/search/enterprise/all-in-one/artifacts-25.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: current
 artifacts:
   alfresco-elasticsearch-live-indexing:
     name: alfresco-elasticsearch-live-indexing
-    version: 5.1.0
+    version: 5.1.1
     classifier: "-app.jar"
     repository: enterprise-releases
     group: org.alfresco

--- a/search/enterprise/common/artifacts-23.yaml
+++ b/search/enterprise/common/artifacts-23.yaml
@@ -4,35 +4,35 @@ updatecli_matrix_version: 23.N
 artifacts:
   alfresco-elasticsearch-live-indexing-mediation:
     name: alfresco-elasticsearch-live-indexing-mediation
-    version: 5.1.0
+    version: 5.1.1
     classifier: "-app.jar"
     repository: enterprise-releases
     group: org.alfresco
     path: search/enterprise/common
   alfresco-elasticsearch-live-indexing-metadata:
     name: alfresco-elasticsearch-live-indexing-metadata
-    version: 5.1.0
+    version: 5.1.1
     classifier: "-app.jar"
     repository: enterprise-releases
     group: org.alfresco
     path: search/enterprise/common
   alfresco-elasticsearch-live-indexing-path:
     name: alfresco-elasticsearch-live-indexing-path
-    version: 5.1.0
+    version: 5.1.1
     classifier: "-app.jar"
     repository: enterprise-releases
     group: org.alfresco
     path: search/enterprise/common
   alfresco-elasticsearch-live-indexing-content:
     name: alfresco-elasticsearch-live-indexing-content
-    version: 5.1.0
+    version: 5.1.1
     classifier: "-app.jar"
     repository: enterprise-releases
     group: org.alfresco
     path: search/enterprise/common
   alfresco-elasticsearch-live-indexing:
     name: alfresco-elasticsearch-live-indexing
-    version: 5.1.0
+    version: 5.1.1
     classifier: "-app.jar"
     repository: enterprise-releases
     group: org.alfresco

--- a/search/enterprise/common/artifacts-25.yaml
+++ b/search/enterprise/common/artifacts-25.yaml
@@ -4,35 +4,35 @@ updatecli_matrix_version: current
 artifacts:
   alfresco-elasticsearch-live-indexing-mediation:
     name: alfresco-elasticsearch-live-indexing-mediation
-    version: 5.1.0
+    version: 5.1.1
     classifier: "-app.jar"
     repository: enterprise-releases
     group: org.alfresco
     path: search/enterprise/common
   alfresco-elasticsearch-live-indexing-metadata:
     name: alfresco-elasticsearch-live-indexing-metadata
-    version: 5.1.0
+    version: 5.1.1
     classifier: "-app.jar"
     repository: enterprise-releases
     group: org.alfresco
     path: search/enterprise/common
   alfresco-elasticsearch-live-indexing-path:
     name: alfresco-elasticsearch-live-indexing-path
-    version: 5.1.0
+    version: 5.1.1
     classifier: "-app.jar"
     repository: enterprise-releases
     group: org.alfresco
     path: search/enterprise/common
   alfresco-elasticsearch-live-indexing-content:
     name: alfresco-elasticsearch-live-indexing-content
-    version: 5.1.0
+    version: 5.1.1
     classifier: "-app.jar"
     repository: enterprise-releases
     group: org.alfresco
     path: search/enterprise/common
   alfresco-elasticsearch-live-indexing:
     name: alfresco-elasticsearch-live-indexing
-    version: 5.1.0
+    version: 5.1.1
     classifier: "-app.jar"
     repository: enterprise-releases
     group: org.alfresco

--- a/search/enterprise/reindexing/artifacts-23.yaml
+++ b/search/enterprise/reindexing/artifacts-23.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: 23.N
 artifacts:
   alfresco-elasticsearch-reindexing:
     name: alfresco-elasticsearch-reindexing
-    version: 5.1.0
+    version: 5.1.1
     classifier: "-app.jar"
     repository: enterprise-releases
     group: org.alfresco

--- a/search/enterprise/reindexing/artifacts-25.yaml
+++ b/search/enterprise/reindexing/artifacts-25.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: current
 artifacts:
   alfresco-elasticsearch-reindexing:
     name: alfresco-elasticsearch-reindexing
-    version: 5.1.0
+    version: 5.1.1
     classifier: "-app.jar"
     repository: enterprise-releases
     group: org.alfresco

--- a/share/artifacts-73.yaml
+++ b/share/artifacts-73.yaml
@@ -5,7 +5,7 @@ updatecli_amps_release_branch: release/7.3.2
 artifacts:
   alfresco-content-services-share-distribution:
     name: alfresco-content-services-share-distribution
-    version: 7.3.2.3
+    version: 7.3.0.9
     classifier: ".zip"
     group: org.alfresco
     repository: enterprise-releases

--- a/tengine/aio/artifacts-23.yaml
+++ b/tengine/aio/artifacts-23.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: 23.N
 artifacts:
   alfresco-transform-core-aio:
     name: alfresco-transform-core-aio
-    version: 5.1.7
+    version: 5.2.0
     classifier: ".jar"
     repository: releases
     group: org.alfresco

--- a/tengine/aio/artifacts-25.yaml
+++ b/tengine/aio/artifacts-25.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: current
 artifacts:
   alfresco-transform-core-aio:
     name: alfresco-transform-core-aio
-    version: 5.1.7
+    version: 5.2.0
     classifier: ".jar"
     repository: releases
     group: org.alfresco

--- a/tengine/aio/artifacts-74.yaml
+++ b/tengine/aio/artifacts-74.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: 7.4.N
 artifacts:
   alfresco-transform-core-aio:
     name: alfresco-transform-core-aio
-    version: 5.1.7
+    version: 5.2.0
     classifier: ".jar"
     repository: releases
     group: org.alfresco

--- a/tengine/imagemagick/artifacts-23.yaml
+++ b/tengine/imagemagick/artifacts-23.yaml
@@ -32,7 +32,7 @@ artifacts:
     path: tengine/imagemagick
   alfresco-transform-imagemagick:
     name: alfresco-transform-imagemagick
-    version: 5.1.7
+    version: 5.2.0
     classifier: ".jar"
     repository: releases
     group: org.alfresco

--- a/tengine/imagemagick/artifacts-25.yaml
+++ b/tengine/imagemagick/artifacts-25.yaml
@@ -32,7 +32,7 @@ artifacts:
     path: tengine/imagemagick
   alfresco-transform-imagemagick:
     name: alfresco-transform-imagemagick
-    version: 5.1.7
+    version: 5.2.0
     classifier: ".jar"
     repository: releases
     group: org.alfresco

--- a/tengine/imagemagick/artifacts-74.yaml
+++ b/tengine/imagemagick/artifacts-74.yaml
@@ -32,7 +32,7 @@ artifacts:
     path: tengine/imagemagick
   alfresco-transform-imagemagick:
     name: alfresco-transform-imagemagick
-    version: 5.1.7
+    version: 5.2.0
     classifier: ".jar"
     repository: releases
     group: org.alfresco

--- a/tengine/libreoffice/artifacts-23.yaml
+++ b/tengine/libreoffice/artifacts-23.yaml
@@ -11,7 +11,7 @@ artifacts:
     path: tengine/libreoffice
   alfresco-transform-libreoffice:
     name: alfresco-transform-libreoffice
-    version: 5.1.7
+    version: 5.2.0
     classifier: ".jar"
     repository: releases
     group: org.alfresco

--- a/tengine/libreoffice/artifacts-25.yaml
+++ b/tengine/libreoffice/artifacts-25.yaml
@@ -11,7 +11,7 @@ artifacts:
     path: tengine/libreoffice
   alfresco-transform-libreoffice:
     name: alfresco-transform-libreoffice
-    version: 5.1.7
+    version: 5.2.0
     classifier: ".jar"
     repository: releases
     group: org.alfresco

--- a/tengine/libreoffice/artifacts-74.yaml
+++ b/tengine/libreoffice/artifacts-74.yaml
@@ -11,7 +11,7 @@ artifacts:
     path: tengine/libreoffice
   alfresco-transform-libreoffice:
     name: alfresco-transform-libreoffice
-    version: 5.1.7
+    version: 5.2.0
     classifier: ".jar"
     repository: releases
     group: org.alfresco

--- a/tengine/misc/artifacts-23.yaml
+++ b/tengine/misc/artifacts-23.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: 23.N
 artifacts:
   alfresco-transform-misc:
     name: alfresco-transform-misc
-    version: 5.1.7
+    version: 5.2.0
     classifier: ".jar"
     repository: releases
     group: org.alfresco

--- a/tengine/misc/artifacts-25.yaml
+++ b/tengine/misc/artifacts-25.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: current
 artifacts:
   alfresco-transform-misc:
     name: alfresco-transform-misc
-    version: 5.1.7
+    version: 5.2.0
     classifier: ".jar"
     repository: releases
     group: org.alfresco

--- a/tengine/misc/artifacts-74.yaml
+++ b/tengine/misc/artifacts-74.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: 7.4.N
 artifacts:
   alfresco-transform-misc:
     name: alfresco-transform-misc
-    version: 5.1.7
+    version: 5.2.0
     classifier: ".jar"
     repository: releases
     group: org.alfresco

--- a/tengine/pdfrenderer/artifacts-23.yaml
+++ b/tengine/pdfrenderer/artifacts-23.yaml
@@ -18,7 +18,7 @@ artifacts:
     group: org.alfresco
   alfresco-pdf-renderer-jar:
     name: alfresco-transform-pdf-renderer
-    version: 5.1.7
+    version: 5.2.0
     path: tengine/pdfrenderer
     classifier: ".jar"
     repository: releases

--- a/tengine/pdfrenderer/artifacts-25.yaml
+++ b/tengine/pdfrenderer/artifacts-25.yaml
@@ -18,7 +18,7 @@ artifacts:
     group: org.alfresco
   alfresco-pdf-renderer-jar:
     name: alfresco-transform-pdf-renderer
-    version: 5.1.7
+    version: 5.2.0
     path: tengine/pdfrenderer
     classifier: ".jar"
     repository: releases

--- a/tengine/pdfrenderer/artifacts-74.yaml
+++ b/tengine/pdfrenderer/artifacts-74.yaml
@@ -18,7 +18,7 @@ artifacts:
     group: org.alfresco
   alfresco-pdf-renderer-jar:
     name: alfresco-transform-pdf-renderer
-    version: 5.1.7
+    version: 5.2.0
     path: tengine/pdfrenderer
     classifier: ".jar"
     repository: releases

--- a/tengine/tika/artifacts-23.yaml
+++ b/tengine/tika/artifacts-23.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: 23.N
 artifacts:
   alfresco-transform-tika:
     name: alfresco-transform-tika
-    version: 5.1.7
+    version: 5.2.0
     classifier: ".jar"
     repository: releases
     group: org.alfresco

--- a/tengine/tika/artifacts-25.yaml
+++ b/tengine/tika/artifacts-25.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: current
 artifacts:
   alfresco-transform-tika:
     name: alfresco-transform-tika
-    version: 5.1.7
+    version: 5.2.0
     classifier: ".jar"
     repository: releases
     group: org.alfresco

--- a/tengine/tika/artifacts-74.yaml
+++ b/tengine/tika/artifacts-74.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: 7.4.N
 artifacts:
   alfresco-transform-tika:
     name: alfresco-transform-tika
-    version: 5.1.7
+    version: 5.2.0
     classifier: ".jar"
     repository: releases
     group: org.alfresco


### PR DESCRIPTION
### Related Issue
[OPSEXP-3292]

Review usage of **stefanzweifel/git-auto-commit-action** and bump version to v6
Please refer release notes [Release v6.0.0 · stefanzweifel/git-auto-commit-action](https://github.com/stefanzweifel/git-auto-commit-action/releases/tag/v6.0.0)
### Changes introduced
Updated stefanzweifel/git-auto-commit-action to [stefanzweifel/git-auto-commit-action@778341a](https://github.com/stefanzweifel/git-auto-commit-action/commit/778341af668090896ca464160c2def5d1d1a3eb0) (#v6.0.1) in below workflow
.github/workflows/bumpVersions.yml