### PR TITLE
OPSEXP-3348 Update release checklist to remember about aps images

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,7 @@ For authentication check out [nexus authentication](#nexus-authentication)
 - Run the [updatecli
   workflow](https://github.com/Alfresco/alfresco-dockerfiles-bakery/actions/workflows/bumpVersions.yml)
   and review the changes.
+- Review and manually update the `aps` images as they are not yet supported in updatecli workflow
 - Agree on a name for the release and make sure to add it to the release notes.
 
 Once everything has been merged to master, you can proceed to create a release with:


### PR DESCRIPTION
### Description

Add an item in the release docs to manually review and update the `aps` images since they are not yet supported in the `updatecli` workflow.

### Related Issue

OPSEXP-3348

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have updated the documentation accordingly.
