### PR TITLE
OPSEXP-4095 Update support.hyland.com and docs.alfresco.com references to docs.hyland.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![CI from forks](https://github.com/Alfresco/alfresco-dockerfiles-bakery/actions/workflows/build_forks.yml/badge.svg)](https://github.com/Alfresco/alfresco-dockerfiles-bakery/actions/workflows/build_forks.yml)
 
 As outlined in the [Hyland Alfresco support
-policy](https://docs.alfresco.com/support/latest/policies/deployment/),
+policy](https://docs.hyland.com/r/Alfresco/Alfresco-Content-Services/23.7/Alfresco-Content-Services/Install/Overview/Install-and-deploy-methods),
 pre-built container images are intended as reference for creating your own
 customized images, incorporating deployment guidelines, security best practices,
 and any necessary custom extensions. While this policy remains unchanged, we are

--- a/repository/amps/README.md
+++ b/repository/amps/README.md
@@ -21,6 +21,6 @@ You can replace those, remove them to keep only the ones you need or add more.
 Be careful though as some AMPs may depend on one another (e.g.
 `googldrive-repo` depends on `alfresco-share-services`).
 
-[sdk]: https://support.hyland.com/r/Alfresco/Alfresco-In-Process-SDK/4.10/Alfresco-In-Process-SDK/Introduction
-[oop]: https://support.hyland.com/r/Alfresco/Alfresco-Content-Services/23.4/Alfresco-Content-Services/Develop/Out-of-Process-Extension-Points/Events-Extension-Point
-[amp]: https://support.hyland.com/r/Alfresco/Alfresco-Content-Services/23.4/Alfresco-Content-Services/Develop/Extension-Packaging-Modules/Module-Package-Formats/Alfresco-Module-Package-AMP
+[sdk]: https://docs.hyland.com/r/Alfresco/Alfresco-In-Process-SDK/4.10/Alfresco-In-Process-SDK/Introduction
+[oop]: https://docs.hyland.com/r/Alfresco/Alfresco-Content-Services/23.4/Alfresco-Content-Services/Develop/Out-of-Process-Extension-Points/Events-Extension-Point
+[amp]: https://docs.hyland.com/r/Alfresco/Alfresco-Content-Services/23.4/Alfresco-Content-Services/Develop/Extension-Packaging-Modules/Module-Package-Formats/Alfresco-Module-Package-AMP

--- a/repository/amps/README.md
+++ b/repository/amps/README.md
@@ -22,5 +22,5 @@ Be careful though as some AMPs may depend on one another (e.g.
 `googldrive-repo` depends on `alfresco-share-services`).
 
 [sdk]: https://docs.hyland.com/r/Alfresco/Alfresco-In-Process-SDK/4.10/Alfresco-In-Process-SDK/Introduction
-[oop]: https://docs.hyland.com/r/Alfresco/Alfresco-Content-Services/23.4/Alfresco-Content-Services/Develop/Out-of-Process-Extension-Points/Events-Extension-Point
-[amp]: https://docs.hyland.com/r/Alfresco/Alfresco-Content-Services/23.4/Alfresco-Content-Services/Develop/Extension-Packaging-Modules/Module-Package-Formats/Alfresco-Module-Package-AMP
+[oop]: https://docs.hyland.com/r/Alfresco/Alfresco-Content-Services/26.1/Alfresco-Content-Services/Develop/Out-of-Process-Extension-Points/Events-Extension-Point
+[amp]: https://docs.hyland.com/r/Alfresco/Alfresco-Content-Services/26.1/Alfresco-Content-Services/Develop/Extension-Packaging-Modules/Module-Package-Formats/Alfresco-Module-Package-AMP

--- a/repository/simple_modules/README.md
+++ b/repository/simple_modules/README.md
@@ -1,7 +1,7 @@
 # Alfresco Content Repository Simple Module (JAR)
 
 You can read the full documentation about Simple Module in the [Alfresco
-documentation](https://support.hyland.com/search/all?query=simple+module+jars&value-filters=platform_custom~%2522Alfresco%2522&content-lang=en-US).
+documentation](https://docs.hyland.com/search/all?query=simple+module+jars&value-filters=platform_custom~%2522Alfresco%2522&content-lang=en-US).
 
 Copy jar files produced by the [Alfresco
 SDK](https://github.com/Alfresco/alfresco-sdk) into `repository/simple_modules`

--- a/search/service/README.md
+++ b/search/service/README.md
@@ -100,7 +100,7 @@ files to the final destination volume.
 ### Cross locale search
 
 Cross locale search
-[configuration](https://docs.alfresco.com/insight-engine/latest/config/indexing/#cross-locale)
+[configuration](https://docs.hyland.com/r/Alfresco/Alfresco-Search-and-Insight-Engine/2.0/Alfresco-Search-and-Insight-Engine/Configure/Indexing-recommendations/Cross-Locale)
 should be done in the `$SOLR_HOME/shared.properties` file.
 
 ### Fingerprint configuration
@@ -108,14 +108,14 @@ should be done in the `$SOLR_HOME/shared.properties` file.
 Toggling also requires using a volume for the `solrhome` directory. For
 furthter information, please refer to the
 [official
-documentation](https://docs.alfresco.com/insight-engine/latest/config/performance/#disable-document-fingerprint)
+documentation](https://docs.hyland.com/r/Alfresco/Alfresco-Search-and-Insight-Engine/2.0/Alfresco-Search-and-Insight-Engine/Configure/Performance-Recommendations/Disable-document-FINGERPRINT)
 
 ### Solr Caches configuration
 
 The Solr caches configuration can be done in the `solrcore.properties` file
 and so requires a volume for the `solrhome` directory. For further information,
 please refer to the [cache configuration
-documentation](https://docs.alfresco.com/insight-engine/latest/config/performance/#disable-solr-document-cache)
+documentation](https://docs.hyland.com/r/Alfresco/Alfresco-Search-and-Insight-Engine/2.0/Alfresco-Search-and-Insight-Engine/Configure/Performance-Recommendations/Disable-SOLR-Document-Cache)
 
 ### Merging configuration
 
@@ -123,7 +123,7 @@ Index merging is a command and often sensitive operation. You may want to
 configure it to your needs. Solr again, do not expose environment variables for
 this, so you need to use a volume for the `solrhome` directory. For further
 information, please refer to the [Merging Parameters
-documentation](https://docs.alfresco.com/insight-engine/latest/config/performance/#merging-parameters)
+documentation](https://docs.hyland.com/r/Alfresco/Alfresco-Search-and-Insight-Engine/2.0/Alfresco-Search-and-Insight-Engine/Configure/Performance-Recommendations/Merging-parameters)
 
 ## Solr replication
 

--- a/sync/README.md
+++ b/sync/README.md
@@ -43,4 +43,4 @@ docker run -e JAVA_OPTS="-Drepo.hostname=alfresco" \
 > chart, you can use other [higher level means of
 > configuration](https://github.com/Alfresco/alfresco-helm-charts/blob/main/charts/alfresco-sync-service/README.md).
 
-[sync]: https://docs.hyland.com/r/Alfresco/Alfresco-Sync-Service/5.1/Alfresco-Sync-Service/Configure/Overview/Required-properties
+[sync]: https://docs.hyland.com/r/Alfresco/Alfresco-Sync-Service/5.3/Alfresco-Sync-Service/Configure/Overview/Required-properties

--- a/sync/README.md
+++ b/sync/README.md
@@ -43,4 +43,4 @@ docker run -e JAVA_OPTS="-Drepo.hostname=alfresco" \
 > chart, you can use other [higher level means of
 > configuration](https://github.com/Alfresco/alfresco-helm-charts/blob/main/charts/alfresco-sync-service/README.md).
 
-[sync]: https://support.hyland.com/r/Alfresco/Alfresco-Sync-Service/5.1/Alfresco-Sync-Service/Configure/Overview/Required-properties
+[sync]: https://docs.hyland.com/r/Alfresco/Alfresco-Sync-Service/5.1/Alfresco-Sync-Service/Configure/Overview/Required-properties

--- a/test/configs/aps-app.properties
+++ b/test/configs/aps-app.properties
@@ -25,7 +25,7 @@ admin.passwordHash=25a463679c56c474f20d8f592e899ef4cb3f79177c19e3782ed827b5c0135
 admin.lastname=Administrator
 admin.group=Administrators
 
-# https://support.hyland.com/p/alfresco  #contentStorageConfig for reference
+# https://docs.hyland.com/p/alfresco  #contentStorageConfig for reference
 contentstorage.fs.rootFolder=/usr/local/data/
 contentstorage.fs.createRoot=true
 contentstorage.fs.depth=4


### PR DESCRIPTION
[OPSEXP-4095](https://hyland.atlassian.net/browse/OPSEXP-4095)
Updated documentation references to use the consolidated Hyland documentation portal:

Replaced https://support.hyland.com/
Replaced https://docs.alfresco.com/

with: https://docs.hyland.com/


[OPSEXP-4095]: https://hyland.atlassian.net/browse/OPSEXP-4095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ