### PR TITLE
Fix intermittent Tomcat bump failure due to git tag ahead of Apache archive

### DIFF
--- a/.github/get-tomcat-version.sh
+++ b/.github/get-tomcat-version.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -e
+set -o pipefail
+
+TOMCAT_MAJOR="${1:?Usage: $0 <major_version>}"
+
+curl -sf "https://downloads.apache.org/tomcat/tomcat-${TOMCAT_MAJOR}/" \
+  | grep -oP 'href="v\K[0-9]+\.[0-9]+\.[0-9]+(?=/)' \
+  | sort -V \
+  | tail -1

--- a/.github/updatecli_tomcat.tpl
+++ b/.github/updatecli_tomcat.tpl
@@ -7,12 +7,11 @@ sources:
 
   tomcat{{ $tomcatMajor }}Version:
     name: Get latest tomcat {{ $tomcatMajor }} version
-    kind: gittag
-    scmid: tomcat
+    kind: shell
     spec:
-      versionfilter:
-        kind: semver
-        pattern: ~{{ $tomcatMajor }}
+      command: .github/get-tomcat-version.sh {{ $tomcatMajor }}
+      environments:
+        - name: PATH
   {{ $tomcatSourceRef := printf "tomcat%sVersion" $tomcatMajor }}
   tomcat{{ $tomcatMajor }}Checksum:
     name: Get tomcat {{ $tomcatMajor }} archive checksum
@@ -87,8 +86,3 @@ scms:
       username: {{ requiredEnv "UPDATECLI_GITHUB_USERNAME" }}
       user: {{ requiredEnv "UPDATECLI_GITHUB_USERNAME" }}
       email: {{ requiredEnv "UPDATECLI_GITHUB_EMAIL" }}
-  tomcat:
-    kind: git
-    spec:
-      url: https://github.com/apache/tomcat.git
-      branch: main


### PR DESCRIPTION
## Summary

This adopts the same approach already used in [alfresco-docker-base-tomcat](https://github.com/Alfresco/alfresco-docker-base-tomcat): replace the `gittag` version source with a shell script that queries the Apache downloads CDN, which only lists fully published releases.

- Add `.github/get-tomcat-version.sh` — queries `downloads.apache.org` for the latest available release of a given Tomcat major version (no extra tools required, unlike the base-tomcat repo which uses `htmlq`).
- Replace the `gittag` source in `updatecli_tomcat.tpl` with a `shell` source backed by the new script.
- Remove the now-unused `tomcat` git SCM entry from the template.

## Background

The scheduled "Bump tomcat versions" job was failing intermittently (e.g. run [28775690806](https://github.com/Alfresco/alfresco-dockerfiles-bakery/actions/runs/28775690806)) because the `gittag` source picked up Tomcat 11.0.24 shortly after it was tagged but before it was published to `archive.apache.org`. The `tomcat11Checksum` source then tried to fetch a SHA-512 that returned 404, and because updatecli evaluates all `{{ source ... }}` expressions at template-render time, the failure cascaded to all four targets — even though a condition (`tomcatXXtargz`) was already present to guard against this. Conditions only gate targets, not sources.

## Test plan

- [ ] Trigger the "Bump tomcat versions" job manually via `workflow_dispatch` and confirm it completes without error.
- [ ] Confirm the script returns the correct latest version for both major 10 and 11.