### PR TITLE
OPSEXP-4209 Bump tags for Nitrogen release

### DIFF
--- a/.github/actions/acs-deployment/action.yml
+++ b/.github/actions/acs-deployment/action.yml
@@ -7,5 +7,5 @@ runs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: Alfresco/acs-deployment
-          ref: v10.6.0
+          ref: v10.7.0
           path: acs-deployment

--- a/.github/actions/aps-deployment/action.yml
+++ b/.github/actions/aps-deployment/action.yml
@@ -11,6 +11,6 @@ runs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: Alfresco/alfresco-process-services-deployment
-          ref: v3.3.0
+          ref: v3.4.0
           token: ${{ inputs.token }}
           path: aps-deployment

--- a/.github/workflows/bumpVersions.yml
+++ b/.github/workflows/bumpVersions.yml
@@ -63,10 +63,10 @@ jobs:
         run: |
           set -x
           find . -type f -name 'artifacts-*.yaml' | while read -r i; do
-             updatecli apply -c .github/updatecli.tpl      -v ${i} -v .github/updatecli_values.yaml -v alfresco-updatecli/deployments/values/supported-matrix.yaml
+             updatecli pipeline apply -c .github/updatecli.tpl      -v ${i} -v .github/updatecli_values.yaml -v alfresco-updatecli/deployments/values/supported-matrix.yaml
 
             if yq -e '.updatecli_amps_release_branch' ${i} > /dev/null; then
-              updatecli apply -c .github/updatecli_amps.tpl -v ${i} -v .github/updatecli_amps_values.yaml
+              updatecli pipeline apply -c .github/updatecli_amps.tpl -v ${i} -v .github/updatecli_amps_values.yaml
             fi
           done
         env:
@@ -108,7 +108,7 @@ jobs:
           restore-keys: |
             updatecli-tomcat-v1-
 
-      - run: updatecli apply -c .github/updatecli_tomcat.tpl
+      - run: updatecli pipeline apply -c .github/updatecli_tomcat.tpl
         env:
           UPDATECLI_GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
           UPDATECLI_GITHUB_USERNAME: ${{ vars.BOT_GITHUB_USERNAME }}
@@ -127,7 +127,7 @@ jobs:
       - name: Install Updatecli
         uses: Alfresco/alfresco-build-tools/.github/actions/setup-updatecli@v17.6.0
 
-      - run: updatecli apply -c .github/updatecli_dockerfile.tpl
+      - run: updatecli pipeline apply -c .github/updatecli_dockerfile.tpl
         env:
           UPDATECLI_GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
           UPDATECLI_GITHUB_USERNAME: ${{ vars.BOT_GITHUB_USERNAME }}

--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,8 @@ artifacts_cache
 *.war
 
 # Files pulled from acs-deployment to test deployment
-acs-deployment
+/acs-deployment
+/aps-deployment
 test/compose.yaml
 test/community-compose.yaml
 test/*-compose.yaml
@@ -26,7 +27,7 @@ test/helm/community-integration-test-values.yaml
 test/helm/community_values.yaml
 
 # CI/CD
-alfresco-updatecli
+/alfresco-updatecli
 .idea
 .vscode
 .vagrant

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ test/helm/community_values.yaml
 .idea
 .vscode
 .vagrant
+.claude
 .venv
 venv
 mise.toml

--- a/adf-apps/acc/artifacts-23.yaml
+++ b/adf-apps/acc/artifacts-23.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: 23.N
 artifacts:
   alfresco-control-center:
     name: alfresco-control-center
-    version: 10.5.0
+    version: 11.0.0
     classifier: ".zip"
     group: org.alfresco
     repository: releases

--- a/adf-apps/acc/artifacts-25.yaml
+++ b/adf-apps/acc/artifacts-25.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: 25.N
 artifacts:
   alfresco-control-center:
     name: alfresco-control-center
-    version: 10.5.0
+    version: 11.0.0
     classifier: ".zip"
     group: org.alfresco
     repository: releases

--- a/adf-apps/acc/artifacts-26.yaml
+++ b/adf-apps/acc/artifacts-26.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: current
 artifacts:
   alfresco-control-center:
     name: alfresco-control-center
-    version: 10.5.0
+    version: 11.0.0
     classifier: ".zip"
     group: org.alfresco
     repository: releases

--- a/adf-apps/adw/artifacts-23.yaml
+++ b/adf-apps/adw/artifacts-23.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: 23.N
 artifacts:
   alfresco-digital-workspace:
     name: alfresco-digital-workspace
-    version: 7.5.0
+    version: 8.0.0
     classifier: ".zip"
     group: org.alfresco
     repository: enterprise-releases

--- a/adf-apps/adw/artifacts-25.yaml
+++ b/adf-apps/adw/artifacts-25.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: 25.N
 artifacts:
   alfresco-digital-workspace:
     name: alfresco-digital-workspace
-    version: 7.5.0
+    version: 8.0.0
     classifier: ".zip"
     group: org.alfresco
     repository: enterprise-releases

--- a/adf-apps/adw/artifacts-26.yaml
+++ b/adf-apps/adw/artifacts-26.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: current
 artifacts:
   alfresco-digital-workspace:
     name: alfresco-digital-workspace
-    version: 7.5.0
+    version: 8.0.0
     classifier: ".zip"
     group: org.alfresco
     repository: enterprise-releases

--- a/aps/admin/artifacts-26.yaml
+++ b/aps/admin/artifacts-26.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: current
 artifacts:
   alfresco-process-services-admin:
     name: activiti-admin
-    version: 26.1.0
+    version: 26.2.0
     classifier: ".war"
     group: com.activiti
     repository: activiti-enterprise-releases

--- a/aps/app/artifacts-26.yaml
+++ b/aps/app/artifacts-26.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: current
 artifacts:
   alfresco-process-services-app:
     name: activiti-app
-    version: 26.1.0
+    version: 26.2.0
     classifier: ".war"
     group: com.activiti
     repository: activiti-enterprise-releases

--- a/ats/sfs/artifacts-23.yaml
+++ b/ats/sfs/artifacts-23.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: 23.N
 artifacts:
   alfresco-shared-file-store-controller:
     name: alfresco-shared-file-store-controller
-    version: 4.4.2
+    version: 4.4.3
     classifier: ".jar"
     repository: enterprise-releases
     group: org.alfresco

--- a/ats/sfs/artifacts-25.yaml
+++ b/ats/sfs/artifacts-25.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: 25.N
 artifacts:
   alfresco-shared-file-store-controller:
     name: alfresco-shared-file-store-controller
-    version: 4.4.2
+    version: 4.4.3
     classifier: ".jar"
     repository: enterprise-releases
     group: org.alfresco

--- a/ats/sfs/artifacts-26.yaml
+++ b/ats/sfs/artifacts-26.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: current
 artifacts:
   alfresco-shared-file-store-controller:
     name: alfresco-shared-file-store-controller
-    version: 4.4.2
+    version: 4.4.3
     classifier: ".jar"
     repository: enterprise-releases
     group: org.alfresco

--- a/ats/trouter/artifacts-23.yaml
+++ b/ats/trouter/artifacts-23.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: 23.N
 artifacts:
   alfresco-transform-router:
     name: alfresco-transform-router
-    version: 4.4.2
+    version: 4.4.3
     classifier: ".jar"
     repository: enterprise-releases
     group: org.alfresco

--- a/ats/trouter/artifacts-25.yaml
+++ b/ats/trouter/artifacts-25.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: 25.N
 artifacts:
   alfresco-transform-router:
     name: alfresco-transform-router
-    version: 4.4.2
+    version: 4.4.3
     classifier: ".jar"
     repository: enterprise-releases
     group: org.alfresco

--- a/ats/trouter/artifacts-26.yaml
+++ b/ats/trouter/artifacts-26.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: current
 artifacts:
   alfresco-transform-router:
     name: alfresco-transform-router
-    version: 4.4.2
+    version: 4.4.3
     classifier: ".jar"
     repository: enterprise-releases
     group: org.alfresco

--- a/audit-storage/artifacts-23.yaml
+++ b/audit-storage/artifacts-23.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: 23.N
 artifacts:
   alfresco-audit-storage-app:
     name: alfresco-audit-storage-app
-    version: 1.3.2
+    version: 1.3.3
     classifier: ".jar"
     repository: enterprise-releases
     group: org.alfresco

--- a/audit-storage/artifacts-25.yaml
+++ b/audit-storage/artifacts-25.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: 25.N
 artifacts:
   alfresco-audit-storage-app:
     name: alfresco-audit-storage-app
-    version: 1.3.2
+    version: 1.3.3
     classifier: ".jar"
     repository: enterprise-releases
     group: org.alfresco

--- a/audit-storage/artifacts-26.yaml
+++ b/audit-storage/artifacts-26.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: current
 artifacts:
   alfresco-audit-storage-app:
     name: alfresco-audit-storage-app
-    version: 1.3.2
+    version: 1.3.3
     classifier: ".jar"
     repository: enterprise-releases
     group: org.alfresco

--- a/connector/ms365/artifacts-23.yaml
+++ b/connector/ms365/artifacts-23.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: 23.N
 artifacts:
   onedrive-springboot:
     name: onedrive-springboot
-    version: 2.1.2
+    version: 2.1.3
     classifier: ".jar"
     repository: enterprise-releases
     group: org.alfresco

--- a/connector/ms365/artifacts-25.yaml
+++ b/connector/ms365/artifacts-25.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: 25.N
 artifacts:
   onedrive-springboot:
     name: onedrive-springboot
-    version: 2.1.2
+    version: 2.1.3
     classifier: ".jar"
     repository: enterprise-releases
     group: org.alfresco

--- a/connector/ms365/artifacts-26.yaml
+++ b/connector/ms365/artifacts-26.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: current
 artifacts:
   onedrive-springboot:
     name: onedrive-springboot
-    version: 2.1.2
+    version: 2.1.3
     classifier: ".jar"
     repository: enterprise-releases
     group: org.alfresco

--- a/connector/msteams/artifacts-23.yaml
+++ b/connector/msteams/artifacts-23.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: 23.N
 artifacts:
   alfresco-ms-teams-springboot:
     name: alfresco-ms-teams-springboot
-    version: 2.1.2
+    version: 2.1.3
     classifier: ".jar"
     repository: enterprise-releases
     group: org.alfresco

--- a/connector/msteams/artifacts-25.yaml
+++ b/connector/msteams/artifacts-25.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: 25.N
 artifacts:
   alfresco-ms-teams-springboot:
     name: alfresco-ms-teams-springboot
-    version: 2.1.2
+    version: 2.1.3
     classifier: ".jar"
     repository: enterprise-releases
     group: org.alfresco

--- a/connector/msteams/artifacts-26.yaml
+++ b/connector/msteams/artifacts-26.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: current
 artifacts:
   alfresco-ms-teams-springboot:
     name: alfresco-ms-teams-springboot
-    version: 2.1.2
+    version: 2.1.3
     classifier: ".jar"
     repository: enterprise-releases
     group: org.alfresco

--- a/repository/artifacts-23.yaml
+++ b/repository/artifacts-23.yaml
@@ -13,7 +13,7 @@ artifacts:
     checksum: "sha1:"
   alfresco-share-services:
     name: alfresco-share-services
-    version: 23.7.0.42
+    version: 23.7.2.1
     path: repository/amps
     classifier: ".amp"
     group: org.alfresco
@@ -45,7 +45,7 @@ artifacts:
     checksum: "sha1:"
   alfresco-content-services-distribution:
     name: alfresco-content-services-distribution
-    version: 23.7.0
+    version: 23.7.1
     path: repository/distribution
     classifier: ".zip"
     group: org.alfresco

--- a/repository/artifacts-25.yaml
+++ b/repository/artifacts-25.yaml
@@ -13,7 +13,7 @@ artifacts:
     checksum: "sha1:"
   alfresco-share-services:
     name: alfresco-share-services
-    version: 25.4.0.61
+    version: 25.4.2.1
     path: repository/amps
     classifier: ".amp"
     group: org.alfresco

--- a/repository/artifacts-26.yaml
+++ b/repository/artifacts-26.yaml
@@ -1,7 +1,7 @@
 ---
 updatecli_self: repository/artifacts-26.yaml
 updatecli_matrix_version: current
-updatecli_amps_release_branch: release/26.1
+updatecli_amps_release_branch: release/26.2
 artifacts:
   postgresql:
     name: postgresql

--- a/repository/artifacts-26.yaml
+++ b/repository/artifacts-26.yaml
@@ -13,7 +13,7 @@ artifacts:
     checksum: "sha1:"
   alfresco-share-services:
     name: alfresco-share-services
-    version: 26.1.0.61
+    version: 26.2.1.1
     path: repository/amps
     classifier: ".amp"
     group: org.alfresco
@@ -29,7 +29,7 @@ artifacts:
     checksum: "sha1:"
   alfresco-device-sync-repo:
     name: alfresco-device-sync-repo
-    version: 5.3.1
+    version: 5.3.5
     path: repository/amps_enterprise
     classifier: ".amp"
     group: org.alfresco.services.sync

--- a/repository/artifacts-26.yaml
+++ b/repository/artifacts-26.yaml
@@ -29,7 +29,7 @@ artifacts:
     checksum: "sha1:"
   alfresco-device-sync-repo:
     name: alfresco-device-sync-repo
-    version: 5.3.4
+    version: 5.3.1
     path: repository/amps_enterprise
     classifier: ".amp"
     group: org.alfresco.services.sync
@@ -45,7 +45,7 @@ artifacts:
     checksum: "sha1:"
   alfresco-content-services-distribution:
     name: alfresco-content-services-distribution
-    version: 26.1.0
+    version: 26.2.1
     path: repository/distribution
     classifier: ".zip"
     group: org.alfresco
@@ -53,7 +53,7 @@ artifacts:
     checksum: "sha1:"
   alfresco-content-services-community-distribution:
     name: alfresco-content-services-community-distribution
-    version: 26.1.0
+    version: 26.2.0
     path: repository/distribution
     classifier: ".zip"
     group: org.alfresco

--- a/search/enterprise/all-in-one/artifacts-23.yaml
+++ b/search/enterprise/all-in-one/artifacts-23.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: 23.N
 artifacts:
   alfresco-elasticsearch-live-indexing:
     name: alfresco-elasticsearch-live-indexing
-    version: 5.6.0
+    version: 5.7.0
     classifier: "-app.jar"
     repository: enterprise-releases
     group: org.alfresco

--- a/search/enterprise/all-in-one/artifacts-25.yaml
+++ b/search/enterprise/all-in-one/artifacts-25.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: 25.N
 artifacts:
   alfresco-elasticsearch-live-indexing:
     name: alfresco-elasticsearch-live-indexing
-    version: 5.6.0
+    version: 5.7.0
     classifier: "-app.jar"
     repository: enterprise-releases
     group: org.alfresco

--- a/search/enterprise/all-in-one/artifacts-26.yaml
+++ b/search/enterprise/all-in-one/artifacts-26.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: current
 artifacts:
   alfresco-elasticsearch-live-indexing:
     name: alfresco-elasticsearch-live-indexing
-    version: 5.6.0
+    version: 5.7.0
     classifier: "-app.jar"
     repository: enterprise-releases
     group: org.alfresco

--- a/search/enterprise/common/artifacts-23.yaml
+++ b/search/enterprise/common/artifacts-23.yaml
@@ -4,35 +4,35 @@ updatecli_matrix_version: 23.N
 artifacts:
   alfresco-elasticsearch-live-indexing-mediation:
     name: alfresco-elasticsearch-live-indexing-mediation
-    version: 5.6.0
+    version: 5.7.0
     classifier: "-app.jar"
     repository: enterprise-releases
     group: org.alfresco
     path: search/enterprise/common
   alfresco-elasticsearch-live-indexing-metadata:
     name: alfresco-elasticsearch-live-indexing-metadata
-    version: 5.6.0
+    version: 5.7.0
     classifier: "-app.jar"
     repository: enterprise-releases
     group: org.alfresco
     path: search/enterprise/common
   alfresco-elasticsearch-live-indexing-path:
     name: alfresco-elasticsearch-live-indexing-path
-    version: 5.6.0
+    version: 5.7.0
     classifier: "-app.jar"
     repository: enterprise-releases
     group: org.alfresco
     path: search/enterprise/common
   alfresco-elasticsearch-live-indexing-content:
     name: alfresco-elasticsearch-live-indexing-content
-    version: 5.6.0
+    version: 5.7.0
     classifier: "-app.jar"
     repository: enterprise-releases
     group: org.alfresco
     path: search/enterprise/common
   alfresco-elasticsearch-live-indexing:
     name: alfresco-elasticsearch-live-indexing
-    version: 5.6.0
+    version: 5.7.0
     classifier: "-app.jar"
     repository: enterprise-releases
     group: org.alfresco

--- a/search/enterprise/common/artifacts-25.yaml
+++ b/search/enterprise/common/artifacts-25.yaml
@@ -4,35 +4,35 @@ updatecli_matrix_version: 25.N
 artifacts:
   alfresco-elasticsearch-live-indexing-mediation:
     name: alfresco-elasticsearch-live-indexing-mediation
-    version: 5.6.0
+    version: 5.7.0
     classifier: "-app.jar"
     repository: enterprise-releases
     group: org.alfresco
     path: search/enterprise/common
   alfresco-elasticsearch-live-indexing-metadata:
     name: alfresco-elasticsearch-live-indexing-metadata
-    version: 5.6.0
+    version: 5.7.0
     classifier: "-app.jar"
     repository: enterprise-releases
     group: org.alfresco
     path: search/enterprise/common
   alfresco-elasticsearch-live-indexing-path:
     name: alfresco-elasticsearch-live-indexing-path
-    version: 5.6.0
+    version: 5.7.0
     classifier: "-app.jar"
     repository: enterprise-releases
     group: org.alfresco
     path: search/enterprise/common
   alfresco-elasticsearch-live-indexing-content:
     name: alfresco-elasticsearch-live-indexing-content
-    version: 5.6.0
+    version: 5.7.0
     classifier: "-app.jar"
     repository: enterprise-releases
     group: org.alfresco
     path: search/enterprise/common
   alfresco-elasticsearch-live-indexing:
     name: alfresco-elasticsearch-live-indexing
-    version: 5.6.0
+    version: 5.7.0
     classifier: "-app.jar"
     repository: enterprise-releases
     group: org.alfresco

--- a/search/enterprise/common/artifacts-26.yaml
+++ b/search/enterprise/common/artifacts-26.yaml
@@ -4,35 +4,35 @@ updatecli_matrix_version: current
 artifacts:
   alfresco-elasticsearch-live-indexing-mediation:
     name: alfresco-elasticsearch-live-indexing-mediation
-    version: 5.6.0
+    version: 5.7.0
     classifier: "-app.jar"
     repository: enterprise-releases
     group: org.alfresco
     path: search/enterprise/common
   alfresco-elasticsearch-live-indexing-metadata:
     name: alfresco-elasticsearch-live-indexing-metadata
-    version: 5.6.0
+    version: 5.7.0
     classifier: "-app.jar"
     repository: enterprise-releases
     group: org.alfresco
     path: search/enterprise/common
   alfresco-elasticsearch-live-indexing-path:
     name: alfresco-elasticsearch-live-indexing-path
-    version: 5.6.0
+    version: 5.7.0
     classifier: "-app.jar"
     repository: enterprise-releases
     group: org.alfresco
     path: search/enterprise/common
   alfresco-elasticsearch-live-indexing-content:
     name: alfresco-elasticsearch-live-indexing-content
-    version: 5.6.0
+    version: 5.7.0
     classifier: "-app.jar"
     repository: enterprise-releases
     group: org.alfresco
     path: search/enterprise/common
   alfresco-elasticsearch-live-indexing:
     name: alfresco-elasticsearch-live-indexing
-    version: 5.6.0
+    version: 5.7.0
     classifier: "-app.jar"
     repository: enterprise-releases
     group: org.alfresco

--- a/search/enterprise/reindexing/artifacts-23.yaml
+++ b/search/enterprise/reindexing/artifacts-23.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: 23.N
 artifacts:
   alfresco-elasticsearch-reindexing:
     name: alfresco-elasticsearch-reindexing
-    version: 5.6.0
+    version: 5.7.0
     classifier: "-app.jar"
     repository: enterprise-releases
     group: org.alfresco

--- a/search/enterprise/reindexing/artifacts-25.yaml
+++ b/search/enterprise/reindexing/artifacts-25.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: 25.N
 artifacts:
   alfresco-elasticsearch-reindexing:
     name: alfresco-elasticsearch-reindexing
-    version: 5.6.0
+    version: 5.7.0
     classifier: "-app.jar"
     repository: enterprise-releases
     group: org.alfresco

--- a/search/enterprise/reindexing/artifacts-26.yaml
+++ b/search/enterprise/reindexing/artifacts-26.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: current
 artifacts:
   alfresco-elasticsearch-reindexing:
     name: alfresco-elasticsearch-reindexing
-    version: 5.6.0
+    version: 5.7.0
     classifier: "-app.jar"
     repository: enterprise-releases
     group: org.alfresco

--- a/search/service/artifacts-23.yaml
+++ b/search/service/artifacts-23.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: 23.N
 artifacts:
   alfresco-search-services:
     name: alfresco-search-services
-    version: 2.0.20
+    version: 2.0.21
     classifier: ".zip"
     repository: releases
     group: org.alfresco

--- a/search/service/artifacts-25.yaml
+++ b/search/service/artifacts-25.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: 25.N
 artifacts:
   alfresco-search-services:
     name: alfresco-search-services
-    version: 2.0.20
+    version: 2.0.21
     classifier: ".zip"
     repository: releases
     group: org.alfresco

--- a/search/service/artifacts-26.yaml
+++ b/search/service/artifacts-26.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: current
 artifacts:
   alfresco-search-services:
     name: alfresco-search-services
-    version: 2.0.20
+    version: 2.0.21-A.2
     classifier: ".zip"
     repository: releases
     group: org.alfresco

--- a/share/artifacts-23.yaml
+++ b/share/artifacts-23.yaml
@@ -5,7 +5,7 @@ updatecli_amps_release_branch: release/23.7
 artifacts:
   alfresco-content-services-share-distribution:
     name: alfresco-content-services-share-distribution
-    version: 23.7.0
+    version: 23.7.1
     classifier: ".zip"
     group: org.alfresco
     repository: enterprise-releases

--- a/share/artifacts-26.yaml
+++ b/share/artifacts-26.yaml
@@ -5,14 +5,14 @@ updatecli_amps_release_branch: release/26.1
 artifacts:
   alfresco-content-services-share-distribution:
     name: alfresco-content-services-share-distribution
-    version: 26.1.0
+    version: 26.2.1
     classifier: ".zip"
     group: org.alfresco
     repository: enterprise-releases
     path: share/distribution
   alfresco-content-services-community-distribution:
     name: alfresco-content-services-community-distribution
-    version: 26.1.0
+    version: 26.2.0
     classifier: ".zip"
     group: org.alfresco
     repository: public

--- a/share/artifacts-26.yaml
+++ b/share/artifacts-26.yaml
@@ -1,7 +1,7 @@
 ---
 updatecli_self: share/artifacts-26.yaml
 updatecli_matrix_version: current
-updatecli_amps_release_branch: release/26.1
+updatecli_amps_release_branch: release/26.2
 artifacts:
   alfresco-content-services-share-distribution:
     name: alfresco-content-services-share-distribution

--- a/sync/artifacts-23.yaml
+++ b/sync/artifacts-23.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: 23.N
 artifacts:
   sync-distribution:
     name: sync-dist-6.x
-    version: 5.3.4
+    version: 5.3.5
     classifier: ".zip"
     group: org.alfresco.services.sync
     repository: enterprise-releases

--- a/sync/artifacts-25.yaml
+++ b/sync/artifacts-25.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: 25.N
 artifacts:
   sync-distribution:
     name: sync-dist-6.x
-    version: 5.3.4
+    version: 5.3.5
     classifier: ".zip"
     group: org.alfresco.services.sync
     repository: enterprise-releases

--- a/sync/artifacts-26.yaml
+++ b/sync/artifacts-26.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: current
 artifacts:
   sync-distribution:
     name: sync-dist-6.x
-    version: 5.3.4
+    version: 5.3.5
     classifier: ".zip"
     group: org.alfresco.services.sync
     repository: enterprise-releases

--- a/tengine/aio/artifacts-23.yaml
+++ b/tengine/aio/artifacts-23.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: 23.N
 artifacts:
   alfresco-transform-core-aio:
     name: alfresco-transform-core-aio
-    version: 5.4.2
+    version: 5.4.3
     classifier: ".jar"
     repository: releases
     group: org.alfresco

--- a/tengine/aio/artifacts-25.yaml
+++ b/tengine/aio/artifacts-25.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: 25.N
 artifacts:
   alfresco-transform-core-aio:
     name: alfresco-transform-core-aio
-    version: 5.4.2
+    version: 5.4.3
     classifier: ".jar"
     repository: releases
     group: org.alfresco

--- a/tengine/aio/artifacts-26.yaml
+++ b/tengine/aio/artifacts-26.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: current
 artifacts:
   alfresco-transform-core-aio:
     name: alfresco-transform-core-aio
-    version: 5.4.2
+    version: 5.4.3
     classifier: ".jar"
     repository: releases
     group: org.alfresco

--- a/tengine/imagemagick/artifacts-23.yaml
+++ b/tengine/imagemagick/artifacts-23.yaml
@@ -32,7 +32,7 @@ artifacts:
     path: tengine/imagemagick
   alfresco-transform-imagemagick:
     name: alfresco-transform-imagemagick
-    version: 5.4.2
+    version: 5.4.3
     classifier: ".jar"
     repository: releases
     group: org.alfresco

--- a/tengine/imagemagick/artifacts-25.yaml
+++ b/tengine/imagemagick/artifacts-25.yaml
@@ -32,7 +32,7 @@ artifacts:
     path: tengine/imagemagick
   alfresco-transform-imagemagick:
     name: alfresco-transform-imagemagick
-    version: 5.4.2
+    version: 5.4.3
     classifier: ".jar"
     repository: releases
     group: org.alfresco

--- a/tengine/imagemagick/artifacts-26.yaml
+++ b/tengine/imagemagick/artifacts-26.yaml
@@ -32,7 +32,7 @@ artifacts:
     path: tengine/imagemagick
   alfresco-transform-imagemagick:
     name: alfresco-transform-imagemagick
-    version: 5.4.2
+    version: 5.4.3
     classifier: ".jar"
     repository: releases
     group: org.alfresco

--- a/tengine/libreoffice/artifacts-23.yaml
+++ b/tengine/libreoffice/artifacts-23.yaml
@@ -11,7 +11,7 @@ artifacts:
     path: tengine/libreoffice
   alfresco-transform-libreoffice:
     name: alfresco-transform-libreoffice
-    version: 5.4.2
+    version: 5.4.3
     classifier: ".jar"
     repository: releases
     group: org.alfresco

--- a/tengine/libreoffice/artifacts-25.yaml
+++ b/tengine/libreoffice/artifacts-25.yaml
@@ -11,7 +11,7 @@ artifacts:
     path: tengine/libreoffice
   alfresco-transform-libreoffice:
     name: alfresco-transform-libreoffice
-    version: 5.4.2
+    version: 5.4.3
     classifier: ".jar"
     repository: releases
     group: org.alfresco

--- a/tengine/libreoffice/artifacts-26.yaml
+++ b/tengine/libreoffice/artifacts-26.yaml
@@ -11,7 +11,7 @@ artifacts:
     path: tengine/libreoffice
   alfresco-transform-libreoffice:
     name: alfresco-transform-libreoffice
-    version: 5.4.2
+    version: 5.4.3
     classifier: ".jar"
     repository: releases
     group: org.alfresco

--- a/tengine/misc/artifacts-23.yaml
+++ b/tengine/misc/artifacts-23.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: 23.N
 artifacts:
   alfresco-transform-misc:
     name: alfresco-transform-misc
-    version: 5.4.2
+    version: 5.4.3
     classifier: ".jar"
     repository: releases
     group: org.alfresco

--- a/tengine/misc/artifacts-25.yaml
+++ b/tengine/misc/artifacts-25.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: 25.N
 artifacts:
   alfresco-transform-misc:
     name: alfresco-transform-misc
-    version: 5.4.2
+    version: 5.4.3
     classifier: ".jar"
     repository: releases
     group: org.alfresco

--- a/tengine/misc/artifacts-26.yaml
+++ b/tengine/misc/artifacts-26.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: current
 artifacts:
   alfresco-transform-misc:
     name: alfresco-transform-misc
-    version: 5.4.2
+    version: 5.4.3
     classifier: ".jar"
     repository: releases
     group: org.alfresco

--- a/tengine/pdfrenderer/artifacts-23.yaml
+++ b/tengine/pdfrenderer/artifacts-23.yaml
@@ -4,21 +4,21 @@ updatecli_matrix_version: 23.N
 artifacts:
   alfresco-pdf-renderer-x64:
     name: alfresco-pdf-renderer
-    version: 1.3.0-76
+    version: 1.3.0-83
     path: tengine/pdfrenderer
     classifier: "-linux.tgz"
     repository: releases
     group: org.alfresco
   alfresco-pdf-renderer-arm:
     name: alfresco-pdf-renderer
-    version: 1.3.0-76
+    version: 1.3.0-83
     path: tengine/pdfrenderer
     classifier: "-linux-arm.tgz"
     repository: releases
     group: org.alfresco
   alfresco-pdf-renderer-jar:
     name: alfresco-transform-pdf-renderer
-    version: 5.4.2
+    version: 5.4.3
     path: tengine/pdfrenderer
     classifier: ".jar"
     repository: releases

--- a/tengine/pdfrenderer/artifacts-25.yaml
+++ b/tengine/pdfrenderer/artifacts-25.yaml
@@ -4,21 +4,21 @@ updatecli_matrix_version: 25.N
 artifacts:
   alfresco-pdf-renderer-x64:
     name: alfresco-pdf-renderer
-    version: 1.3.0-76
+    version: 1.3.0-83
     path: tengine/pdfrenderer
     classifier: "-linux.tgz"
     repository: releases
     group: org.alfresco
   alfresco-pdf-renderer-arm:
     name: alfresco-pdf-renderer
-    version: 1.3.0-76
+    version: 1.3.0-83
     path: tengine/pdfrenderer
     classifier: "-linux-arm.tgz"
     repository: releases
     group: org.alfresco
   alfresco-pdf-renderer-jar:
     name: alfresco-transform-pdf-renderer
-    version: 5.4.2
+    version: 5.4.3
     path: tengine/pdfrenderer
     classifier: ".jar"
     repository: releases

--- a/tengine/pdfrenderer/artifacts-26.yaml
+++ b/tengine/pdfrenderer/artifacts-26.yaml
@@ -4,21 +4,21 @@ updatecli_matrix_version: current
 artifacts:
   alfresco-pdf-renderer-x64:
     name: alfresco-pdf-renderer
-    version: 1.3.0-76
+    version: 1.3.0-83
     path: tengine/pdfrenderer
     classifier: "-linux.tgz"
     repository: releases
     group: org.alfresco
   alfresco-pdf-renderer-arm:
     name: alfresco-pdf-renderer
-    version: 1.3.0-76
+    version: 1.3.0-83
     path: tengine/pdfrenderer
     classifier: "-linux-arm.tgz"
     repository: releases
     group: org.alfresco
   alfresco-pdf-renderer-jar:
     name: alfresco-transform-pdf-renderer
-    version: 5.4.2
+    version: 5.4.3
     path: tengine/pdfrenderer
     classifier: ".jar"
     repository: releases

--- a/tengine/tika/artifacts-23.yaml
+++ b/tengine/tika/artifacts-23.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: 23.N
 artifacts:
   alfresco-transform-tika:
     name: alfresco-transform-tika
-    version: 5.4.2
+    version: 5.4.3
     classifier: ".jar"
     repository: releases
     group: org.alfresco

--- a/tengine/tika/artifacts-25.yaml
+++ b/tengine/tika/artifacts-25.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: 25.N
 artifacts:
   alfresco-transform-tika:
     name: alfresco-transform-tika
-    version: 5.4.2
+    version: 5.4.3
     classifier: ".jar"
     repository: releases
     group: org.alfresco

--- a/tengine/tika/artifacts-26.yaml
+++ b/tengine/tika/artifacts-26.yaml
@@ -4,7 +4,7 @@ updatecli_matrix_version: current
 artifacts:
   alfresco-transform-tika:
     name: alfresco-transform-tika
-    version: 5.4.2
+    version: 5.4.3
     classifier: ".jar"
     repository: releases
     group: org.alfresco

--- a/test/helm/test-overrides-23.yaml
+++ b/test/helm/test-overrides-23.yaml
@@ -5,7 +5,7 @@ dtas:
     assertions:
       acs:
         edition: Enterprise
-        version: 23.7.0
+        version: 23.7.1
         modules:
         - id: org_alfresco_device_sync_repo
           version: 5.3.2

--- a/test/helm/test-overrides-arm64.yaml
+++ b/test/helm/test-overrides-arm64.yaml
@@ -5,5 +5,7 @@ alfresco-repository:
 elasticsearch:
   elasticsearch:
     resources:
+      requests:
+        memory: "1Gi"
       limits:
         memory: "1.5Gi"

--- a/test/helm/test-overrides-community.yaml
+++ b/test/helm/test-overrides-community.yaml
@@ -10,7 +10,7 @@ dtas:
     assertions:
       acs:
         edition: Community
-        version: 26.1.0
+        version: 26.2.0
         modules:
           - id: alfresco-aos-module
             version: 3.4.1

--- a/test/helm/test-overrides-enterprise.yaml
+++ b/test/helm/test-overrides-enterprise.yaml
@@ -5,10 +5,10 @@ dtas:
     assertions:
       acs:
         edition: Enterprise
-        version: 26.1.0
+        version: 26.2.1
         modules:
           - id: org_alfresco_device_sync_repo
-            version: 5.3.4
+            version: 5.3.5
             installed: true
           - id: org.alfresco.integrations.google.docs
             version: 4.1.0


### PR DESCRIPTION
## Summary
Release prep for nitrogen release.

- Bumps the acs-deployment action ref to v10.7.0 and the aps-deployment action ref to v3.4.0.
- Anchors the `acs-deployment`, `aps-deployment`, and `alfresco-updatecli` gitignore patterns to the repo root so they no longer accidentally match the tracked `.github/actions/acs-deployment` and `.github/actions/aps-deployment` directories.
- Automated updatecli pipeline artifacts bump across the various `artifacts-*.yaml` files.
- Bumps `updatecli_amps_release_branch` to `release/26.2` in `repository/artifacts-26.yaml`.
- Switches the `bumpVersions` workflow from the deprecated `updatecli apply` command to `updatecli pipeline apply`.

OPSEXP-4209