### PR TITLE
OPSEXP-4209 Make Grype scan step non-blocking in test-make workflow

### DIFF
--- a/.github/workflows/test-make.yml
+++ b/.github/workflows/test-make.yml
@@ -64,4 +64,5 @@ jobs:
           docker image ls --format '{{.Repository}}:{{.Tag}}' \
             | grep alfresco \
             | xargs -I{} sh -c 'echo "Running scan for {}..." \
-            && grype -f high --only-fixed --ignore-states wont-fix {}'
+            && grype -f high --only-fixed --ignore-states wont-fix {} \
+            || echo "::warning::Grype found vulnerabilities in {}"'


### PR DESCRIPTION
## Summary
The Grype scan step in the test-make workflow currently fails the job when vulnerabilities are found. This changes it to emit a GitHub Actions warning annotation instead, so the job continues and passes.

## Test plan
- [x] Confirm the test-make workflow runs to completion even when Grype finds high-severity vulnerabilities in a built image
- [x] Confirm a warning annotation appears on the job summary/PR checks when vulnerabilities are found

OPSEXP-4209