### PR TITLE
OPSEXP-3899 Move grype scanning out of test-make into a scheduled scan

### DIFF
--- a/.github/workflows/grype-scan.yml
+++ b/.github/workflows/grype-scan.yml
@@ -55,11 +55,17 @@ jobs:
           GRYPE_TARGET=${{ matrix.target }}
           [ "$GRYPE_TARGET" = "repo" ] && GRYPE_TARGET=repository
           make grype GRYPE_TARGET="$GRYPE_TARGET" GRYPE_OUTPUT_DIR=sarif GRYPE_OPTS="--only-fixed --ignore-states wont-fix -o sarif"
-          # Merge into a single multi-run SARIF file: one image = one run, one file = one code-scanning upload.
-          jq -s '{"$schema": .[0]["$schema"], version: .[0].version, runs: (map(.runs) | add)}' sarif/*.out > combined.sarif
+          # Code scanning requires a unique category per run: give each image its own,
+          # via automationDetails.id (takes precedence over the upload-sarif `category` input).
+          # https://github.blog/changelog/2025-07-21-code-scanning-will-stop-combining-multiple-sarif-runs-uploaded-in-the-same-sarif-file/
+          for f in sarif/*.out; do
+            name=$(basename "$f" .out)
+            id="${{ matrix.target }}/$(echo "$name" | sed -E 's/^localhost_alfresco_//; s/_latest_?$//')/"
+            jq --arg id "$id" '.runs[0].automationDetails.id = $id' "$f" > "sarif/$name.sarif"
+            rm "$f"
+          done
 
       - name: Upload SARIF to GitHub code scanning
         uses: github/codeql-action/upload-sarif@ea14db8afdef5d462e69d78c4ca45002d4522418 # v4.37.4
         with:
-          sarif_file: combined.sarif
-          category: ${{ matrix.target }}
+          sarif_file: sarif

--- a/.github/workflows/grype-scan.yml
+++ b/.github/workflows/grype-scan.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [community, adf_apps, ats, audit_storage, connectors, hxinsight_connector, repo, search_enterprise, search_service, share, sync, tengines, aps]
+        target: [community, adf_apps, ats, audit_storage, connectors, hxinsight_connector, repository, search_enterprise, search_service, share, sync, tengines, aps]
     runs-on: ubuntu-latest
     steps:
       - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v17.6.0
@@ -50,10 +50,7 @@ jobs:
 
       - name: Scan built images
         run: |
-          # docker-bake.hcl's target/group is named "repository", unlike the Makefile's "repo" build target.
-          GRYPE_TARGET=${{ matrix.target }}
-          [ "$GRYPE_TARGET" = "repo" ] && GRYPE_TARGET=repository
-          make grype GRYPE_TARGET="$GRYPE_TARGET" GRYPE_OUTPUT_DIR=sarif GRYPE_OPTS="--only-fixed --ignore-states wont-fix -o sarif"
+          make grype GRYPE_TARGET=${{ matrix.target }} GRYPE_OUTPUT_DIR=sarif GRYPE_OPTS="--only-fixed --ignore-states wont-fix -o sarif"
           # Code scanning requires a unique category per run: give each image its own,
           # via automationDetails.id (takes precedence over the upload-sarif `category` input).
           # https://github.blog/changelog/2025-07-21-code-scanning-will-stop-combining-multiple-sarif-runs-uploaded-in-the-same-sarif-file/

--- a/.github/workflows/grype-scan.yml
+++ b/.github/workflows/grype-scan.yml
@@ -62,6 +62,27 @@ jobs:
             rm "$f"
           done
 
+      - name: Summarize results
+        run: |
+          {
+            echo "## Grype scan: ${{ matrix.target }}"
+            for f in sarif/*.sarif; do
+              echo "### $(basename "$f" .sarif)"
+              jq -r '
+                .runs[0].tool.driver.rules // [] as $rules |
+                if ($rules | length) == 0 then
+                  "_No vulnerabilities found._"
+                else
+                  (["| Severity | Package | Version | Fix Version | Type | Location | Data Namespace | Link |",
+                    "| --- | --- | --- | --- | --- | --- | --- | --- |"]
+                    + [$rules[] | (.help.markdown | split("\n")[3])])
+                  | join("\n")
+                end
+              ' "$f"
+              echo
+            done
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Upload SARIF to GitHub code scanning
         uses: github/codeql-action/upload-sarif@ea14db8afdef5d462e69d78c4ca45002d4522418 # v4.37.4
         with:

--- a/.github/workflows/grype-scan.yml
+++ b/.github/workflows/grype-scan.yml
@@ -82,7 +82,7 @@ jobs:
               ' "$f"
               echo
             done
-          } >> "$GITHUB_STEP_SUMMARY"
+          } | tee -a "$GITHUB_STEP_SUMMARY"
 
       - name: Upload SARIF to GitHub code scanning
         uses: github/codeql-action/upload-sarif@ea14db8afdef5d462e69d78c4ca45002d4522418 # v4.37.4

--- a/.github/workflows/grype-scan.yml
+++ b/.github/workflows/grype-scan.yml
@@ -1,7 +1,6 @@
 name: Grype vulnerability scan
 
 on:
-  push:  # TODO: remove, temporary trigger to test this workflow once
   schedule:
     - cron: '30 4 * * 1'  # Weekly, Monday 04:30 UTC
   workflow_dispatch: {}

--- a/.github/workflows/grype-scan.yml
+++ b/.github/workflows/grype-scan.yml
@@ -52,7 +52,6 @@ jobs:
         run: echo "$(dirname ${{ steps.grype-install.outputs.cmd }})" >> "$GITHUB_PATH"
 
       - name: Scan built images
-        continue-on-error: true
         run: |
           make grype GRYPE_TARGET=${{ matrix.target }} GRYPE_OUTPUT_DIR=sarif GRYPE_OUTPUT_FORMAT=sarif GRYPE_OPTS="--only-fixed --ignore-states wont-fix"
 

--- a/.github/workflows/grype-scan.yml
+++ b/.github/workflows/grype-scan.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Scan built images
         run: |
-          make grype GRYPE_TARGET=${{ matrix.target }} GRYPE_OUTPUT_DIR=sarif GRYPE_OPTS="--only-fixed --ignore-states wont-fix -o sarif"
+          make grype GRYPE_TARGET=${{ matrix.target }} GRYPE_OUTPUT_DIR=sarif GRYPE_OUTPUT_FORMAT=sarif GRYPE_OPTS="--only-fixed --ignore-states wont-fix"
           # Code scanning requires a unique category per run: give each image its own,
           # via automationDetails.id (takes precedence over the upload-sarif `category` input).
           # https://github.blog/changelog/2025-07-21-code-scanning-will-stop-combining-multiple-sarif-runs-uploaded-in-the-same-sarif-file/

--- a/.github/workflows/grype-scan.yml
+++ b/.github/workflows/grype-scan.yml
@@ -1,12 +1,13 @@
 name: Grype vulnerability scan
 
 on:
+  push:  # TODO: remove, temporary trigger to test this workflow once
   schedule:
     - cron: '30 4 * * 1'  # Weekly, Monday 04:30 UTC
   workflow_dispatch: {}
 
 concurrency:
-  group: ${{ github.workflow }}
+  group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 
 permissions:
@@ -45,22 +46,17 @@ jobs:
         uses: anchore/scan-action/download-grype@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
         id: grype-install
 
+      - name: Add Grype to PATH
+        run: echo "$(dirname ${{ steps.grype-install.outputs.cmd }})" >> "$GITHUB_PATH"
+
       - name: Scan built images
         run: |
-          mkdir -p sarif
-          images=$(docker image ls --format '{{.Repository}}:{{.Tag}}' | grep alfresco)
-          if [ -z "$images" ]; then
-            echo "No Alfresco image found" >&2
-            exit 1
-          fi
-          i=0
-          while IFS= read -r image; do
-            i=$((i + 1))
-            echo "Scanning $image"
-            ${{ steps.grype-install.outputs.cmd }} "$image" --only-fixed --ignore-states wont-fix -o sarif > "sarif/$i.sarif"
-          done <<< "$images"
+          # docker-bake.hcl's target/group is named "repository", unlike the Makefile's "repo" build target.
+          GRYPE_TARGET=${{ matrix.target }}
+          [ "$GRYPE_TARGET" = "repo" ] && GRYPE_TARGET=repository
+          make grype GRYPE_TARGET="$GRYPE_TARGET" GRYPE_OUTPUT_DIR=sarif GRYPE_OPTS="--only-fixed --ignore-states wont-fix -o sarif"
           # Merge into a single multi-run SARIF file: one image = one run, one file = one code-scanning upload.
-          jq -s '{"$schema": .[0]["$schema"], version: .[0].version, runs: (map(.runs) | add)}' sarif/*.sarif > combined.sarif
+          jq -s '{"$schema": .[0]["$schema"], version: .[0].version, runs: (map(.runs) | add)}' sarif/*.out > combined.sarif
 
       - name: Upload SARIF to GitHub code scanning
         uses: github/codeql-action/upload-sarif@ea14db8afdef5d462e69d78c4ca45002d4522418 # v4.37.4

--- a/.github/workflows/grype-scan.yml
+++ b/.github/workflows/grype-scan.yml
@@ -1,0 +1,69 @@
+name: Grype vulnerability scan
+
+on:
+  schedule:
+    - cron: '30 4 * * 1'  # Weekly, Monday 04:30 UTC
+  workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  scan:
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [community, adf_apps, ats, audit_storage, connectors, hxinsight_connector, repo, search_enterprise, search_service, share, sync, tengines, aps]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v17.6.0
+
+      - name: Setup nexus authentication
+        env:
+          NETRC_PATH: ~/.netrc
+        run: |
+          touch ${{ env.NETRC_PATH }}
+          chmod 600 ${{ env.NETRC_PATH }}
+          echo "machine nexus.alfresco.com" >> ${{ env.NETRC_PATH }}
+          echo "login ${{ secrets.NEXUS_USERNAME_READ_ONLY }}" >> ${{ env.NETRC_PATH }}
+          echo "password ${{ secrets.NEXUS_PASSWORD_READ_ONLY }}" >> ${{ env.NETRC_PATH }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - run: make ${{ matrix.target }}
+
+      - name: Install Grype
+        uses: anchore/scan-action/download-grype@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
+        id: grype-install
+
+      - name: Scan built images
+        run: |
+          mkdir -p sarif
+          images=$(docker image ls --format '{{.Repository}}:{{.Tag}}' | grep alfresco)
+          if [ -z "$images" ]; then
+            echo "No Alfresco image found" >&2
+            exit 1
+          fi
+          i=0
+          while IFS= read -r image; do
+            i=$((i + 1))
+            echo "Scanning $image"
+            ${{ steps.grype-install.outputs.cmd }} "$image" --only-fixed --ignore-states wont-fix -o sarif > "sarif/$i.sarif"
+          done <<< "$images"
+          # Merge into a single multi-run SARIF file: one image = one run, one file = one code-scanning upload.
+          jq -s '{"$schema": .[0]["$schema"], version: .[0].version, runs: (map(.runs) | add)}' sarif/*.sarif > combined.sarif
+
+      - name: Upload SARIF to GitHub code scanning
+        uses: github/codeql-action/upload-sarif@ea14db8afdef5d462e69d78c4ca45002d4522418 # v4.37.4
+        with:
+          sarif_file: combined.sarif
+          category: ${{ matrix.target }}

--- a/.github/workflows/grype-scan.yml
+++ b/.github/workflows/grype-scan.yml
@@ -1,7 +1,6 @@
 name: Grype vulnerability scan
 
 on:
-  push:  # TODO: remove, temporary trigger to re-test this workflow after the repo -> repository rename
   schedule:
     - cron: '30 4 * * 1'  # Weekly, Monday 04:30 UTC
   workflow_dispatch: {}

--- a/.github/workflows/grype-scan.yml
+++ b/.github/workflows/grype-scan.yml
@@ -19,7 +19,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [community, adf_apps, ats, audit_storage, connectors, hxinsight_connector, repository, search_enterprise, search_service, share, sync, tengines, aps]
+        # "community" and "enterprise" are aggregate bake groups: every image they build is
+        # already covered by one of the more granular targets below, so scanning them here
+        # would just rebuild and rescan the same images under a second, redundant category.
+        target: [adf_apps, ats, audit_storage, connectors, hxinsight_connector, repository, search_enterprise, search_service, share, sync, tengines, aps]
     runs-on: ubuntu-latest
     steps:
       - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v17.6.0

--- a/.github/workflows/grype-scan.yml
+++ b/.github/workflows/grype-scan.yml
@@ -1,6 +1,7 @@
 name: Grype vulnerability scan
 
 on:
+  push:  # TODO: remove, temporary trigger to re-test this workflow after the repo -> repository rename
   schedule:
     - cron: '30 4 * * 1'  # Weekly, Monday 04:30 UTC
   workflow_dispatch: {}

--- a/.github/workflows/grype-scan.yml
+++ b/.github/workflows/grype-scan.yml
@@ -70,15 +70,13 @@ jobs:
           {
             echo "## Grype scan: ${{ matrix.target }}"
             for f in sarif/*.sarif; do
-              echo "### $(basename "$f" .sarif)"
+              echo "### $(basename "$f" .sarif | sed -E 's/^localhost_alfresco_//; s/_latest_?$//')"
               jq -r '
                 .runs[0].tool.driver.rules // [] as $rules |
                 if ($rules | length) == 0 then
                   "_No vulnerabilities found._"
                 else
-                  (["| Severity | Package | Version | Fix Version | Type | Location | Data Namespace | Link |",
-                    "| --- | --- | --- | --- | --- | --- | --- | --- |"]
-                    + [$rules[] | (.help.markdown | split("\n")[3])])
+                  [$rules[] | "- **" + (.properties["security-severity"] // "?") + "** " + (.shortDescription.text // .id)]
                   | join("\n")
                 end
               ' "$f"

--- a/.github/workflows/grype-scan.yml
+++ b/.github/workflows/grype-scan.yml
@@ -24,7 +24,7 @@ jobs:
         target: [adf_apps, ats, audit_storage, connectors, hxinsight_connector, repository, search_enterprise, search_service, share, sync, tengines, aps]
     runs-on: ubuntu-latest
     steps:
-      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v17.6.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v18.21.1
 
       - name: Setup nexus authentication
         env:
@@ -37,10 +37,10 @@ jobs:
           echo "password ${{ secrets.NEXUS_PASSWORD_READ_ONLY }}" >> ${{ env.NETRC_PATH }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - run: make ${{ matrix.target }}
 
@@ -52,11 +52,19 @@ jobs:
         run: echo "$(dirname ${{ steps.grype-install.outputs.cmd }})" >> "$GITHUB_PATH"
 
       - name: Scan built images
+        continue-on-error: true
         run: |
           make grype GRYPE_TARGET=${{ matrix.target }} GRYPE_OUTPUT_DIR=sarif GRYPE_OUTPUT_FORMAT=sarif GRYPE_OPTS="--only-fixed --ignore-states wont-fix"
+
+      # Runs even if the scan step above failed partway, so whatever SARIF was
+      # produced before the failure still gets uploaded instead of discarded.
+      - name: Prepare SARIF for code scanning
+        if: always()
+        run: |
           # Code scanning requires a unique category per run: give each image its own,
           # via automationDetails.id (takes precedence over the upload-sarif `category` input).
           # https://github.blog/changelog/2025-07-21-code-scanning-will-stop-combining-multiple-sarif-runs-uploaded-in-the-same-sarif-file/
+          shopt -s nullglob
           for f in sarif/*.out; do
             name=$(basename "$f" .out)
             id="${{ matrix.target }}/$(echo "$name" | sed -E 's/^localhost_alfresco_//; s/_latest_?$//')/"
@@ -65,6 +73,7 @@ jobs:
           done
 
       - name: Upload SARIF to GitHub code scanning
+        if: always()
         uses: github/codeql-action/upload-sarif@ea14db8afdef5d462e69d78c4ca45002d4522418 # v4.37.4
         with:
           sarif_file: sarif

--- a/.github/workflows/grype-scan.yml
+++ b/.github/workflows/grype-scan.yml
@@ -65,25 +65,6 @@ jobs:
             rm "$f"
           done
 
-      - name: Summarize results
-        run: |
-          {
-            echo "## Grype scan: ${{ matrix.target }}"
-            for f in sarif/*.sarif; do
-              echo "### $(basename "$f" .sarif | sed -E 's/^localhost_alfresco_//; s/_latest_?$//')"
-              jq -r '
-                .runs[0].tool.driver.rules // [] as $rules |
-                if ($rules | length) == 0 then
-                  "_No vulnerabilities found._"
-                else
-                  [$rules[] | "- **" + (.properties["security-severity"] // "?") + "** " + (.shortDescription.text // .id)]
-                  | join("\n")
-                end
-              ' "$f"
-              echo
-            done
-          } | tee -a "$GITHUB_STEP_SUMMARY"
-
       - name: Upload SARIF to GitHub code scanning
         uses: github/codeql-action/upload-sarif@ea14db8afdef5d462e69d78c4ca45002d4522418 # v4.37.4
         with:

--- a/.github/workflows/test-make.yml
+++ b/.github/workflows/test-make.yml
@@ -51,18 +51,3 @@ jobs:
         run: |
           echo -n "Checking images are loaded in local Docker Engine..."
           docker images --format "{{.Repository}}:{{.Tag}}" | grep alfresco || { echo "No Alfresco image found"; exit 1; }
-
-      - name: Install Grype
-        uses: anchore/scan-action/download-grype@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
-        id: grype-install
-
-      - name: Add Grype to PATH
-        run: echo "$(dirname ${{ steps.grype-install.outputs.cmd }})" >> $GITHUB_PATH
-
-      - name: Grype scan
-        run: |
-          docker image ls --format '{{.Repository}}:{{.Tag}}' \
-            | grep alfresco \
-            | xargs -I{} sh -c 'echo "Running scan for {}..." \
-            && grype -f high --only-fixed --ignore-states wont-fix {} \
-            || echo "::warning::Grype found vulnerabilities in {}"'

--- a/.github/workflows/test-make.yml
+++ b/.github/workflows/test-make.yml
@@ -22,7 +22,7 @@ jobs:
         target: ${{ fromJSON(
             github.event.pull_request.head.repo.fork
               && '["community"]'
-              || '["community", "adf_apps","ats","audit_storage","connectors","hxinsight_connector","repo","search_enterprise","search_service","share","sync","tengines","aps"]'
+              || '["community", "adf_apps","ats","audit_storage","connectors","hxinsight_connector","repository","search_enterprise","search_service","share","sync","tengines","aps"]'
           ) }}
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -214,10 +214,15 @@ GRYPE_OPTS := -f high --only-fixed --ignore-states wont-fix
 define _grype_impl
 	@command -v grype >/dev/null 2>&1 || { echo >&2 "grype is required but it's not installed. See https://github.com/anchore/grype/blob/main/README.md#installation"; exit 1; }
 	@command -v jq >/dev/null 2>&1 || { echo >&2 "jq is required but it's not installed. See https://jqlang.org/download/"; exit 1; }
+	@if [ -n "$(GRYPE_OUTPUT_DIR)" ]; then mkdir -p "$(GRYPE_OUTPUT_DIR)"; fi
 	@docker buildx bake $(1) --print | jq -r '.target[] | select(.output | any(.type == "docker")) | .tags[]' \
 	| while read tag; do \
 		echo "Scanning image $$tag"; \
-		grype $(GRYPE_OPTS) "$$tag"; \
+		if [ -n "$(GRYPE_OUTPUT_DIR)" ]; then \
+			grype $(GRYPE_OPTS) "$$tag" > "$(GRYPE_OUTPUT_DIR)/$$(echo "$$tag" | tr -c '[:alnum:]_.-' '_').out"; \
+		else \
+			grype $(GRYPE_OPTS) "$$tag"; \
+		fi; \
 	done
 endef
 

--- a/Makefile
+++ b/Makefile
@@ -210,7 +210,6 @@ tengines: docker-bake.hcl prepare_tengines setenv
 	$(call grype_scan,$@)
 
 GRYPE_OPTS := -f high --only-fixed --ignore-states wont-fix
-GRYPE_OUTPUT_FORMAT ?=
 
 define _grype_impl
 	@command -v grype >/dev/null 2>&1 || { echo >&2 "grype is required but it's not installed. See https://github.com/anchore/grype/blob/main/README.md#installation"; exit 1; }
@@ -219,11 +218,9 @@ define _grype_impl
 	@docker buildx bake $(1) --print | jq -r '.target[] | select(.output | any(.type == "docker")) | .tags[]' \
 	| while read tag; do \
 		echo "Scanning image $$tag"; \
-		if [ -n "$(GRYPE_OUTPUT_DIR)" ]; then \
-			grype $(GRYPE_OPTS) $(if $(GRYPE_OUTPUT_FORMAT),-o $(GRYPE_OUTPUT_FORMAT)) "$$tag" > "$(GRYPE_OUTPUT_DIR)/$$(echo "$$tag" | tr -c '[:alnum:]_.-' '_').out"; \
-		else \
-			grype $(GRYPE_OPTS) $(if $(GRYPE_OUTPUT_FORMAT),-o $(GRYPE_OUTPUT_FORMAT)) "$$tag"; \
-		fi; \
+		out=/dev/stdout; \
+		if [ -n "$(GRYPE_OUTPUT_DIR)" ]; then out="$(GRYPE_OUTPUT_DIR)/$$(echo "$$tag" | tr -c '[:alnum:]_.-' '_').out"; fi; \
+		grype $(GRYPE_OPTS) $(if $(GRYPE_OUTPUT_FORMAT),-o $(GRYPE_OUTPUT_FORMAT)) "$$tag" > "$$out"; \
 	done
 endef
 

--- a/Makefile
+++ b/Makefile
@@ -210,6 +210,7 @@ tengines: docker-bake.hcl prepare_tengines setenv
 	$(call grype_scan,$@)
 
 GRYPE_OPTS := -f high --only-fixed --ignore-states wont-fix
+GRYPE_OUTPUT_FORMAT ?=
 
 define _grype_impl
 	@command -v grype >/dev/null 2>&1 || { echo >&2 "grype is required but it's not installed. See https://github.com/anchore/grype/blob/main/README.md#installation"; exit 1; }
@@ -219,9 +220,9 @@ define _grype_impl
 	| while read tag; do \
 		echo "Scanning image $$tag"; \
 		if [ -n "$(GRYPE_OUTPUT_DIR)" ]; then \
-			grype $(GRYPE_OPTS) "$$tag" > "$(GRYPE_OUTPUT_DIR)/$$(echo "$$tag" | tr -c '[:alnum:]_.-' '_').out"; \
+			grype $(GRYPE_OPTS) $(if $(GRYPE_OUTPUT_FORMAT),-o $(GRYPE_OUTPUT_FORMAT)) "$$tag" > "$(GRYPE_OUTPUT_DIR)/$$(echo "$$tag" | tr -c '[:alnum:]_.-' '_').out"; \
 		else \
-			grype $(GRYPE_OPTS) "$$tag"; \
+			grype $(GRYPE_OPTS) $(if $(GRYPE_OUTPUT_FORMAT),-o $(GRYPE_OUTPUT_FORMAT)) "$$tag"; \
 		fi; \
 	done
 endef

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ help:
 	@echo "  audit_storage       Build Audit Storage images"
 	@echo "  connectors          Build MS365/Teams Connectors images"
 	@echo "  hxinsight_connector Build HxInsight Connector images"
-	@echo "  repo                Build Repository image"
+	@echo "  repository          Build Repository image"
 	@echo "  search_enterprise   Build Search Enterprise images"
 	@echo "  search_service      Build Search Service images"
 	@echo "  share               Build Share images"
@@ -179,10 +179,10 @@ hxinsight_connector: docker-bake.hcl prepare_hxinsight_connector setenv
 	docker buildx bake ${DOCKER_BAKE_ARGS} $@
 	$(call grype_scan,$@)
 
-repo: docker-bake.hcl prepare_repo setenv
+repository: docker-bake.hcl prepare_repo setenv
 	@echo "Building Repository images"
-	docker buildx bake ${DOCKER_BAKE_ARGS} repository
-	$(call grype_scan,repository)
+	docker buildx bake ${DOCKER_BAKE_ARGS} $@
+	$(call grype_scan,$@)
 
 search_enterprise: docker-bake.hcl prepare_search_enterprise setenv
 	@echo "Building Search Enterprise images"

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ The `make` wrapper would handle the authentication part for you:
 
 ```sh
 export REGISTRY=myecr.domain.tld REGISTRY_NAMESPACE=myalfrescobuilds TARGETARCH=linux/amd64,linux/arm64
-make repo
+make repository
 ```
 
 You can also run bake directly but you need to be sure to have done the
@@ -248,7 +248,7 @@ additional argument to tell the tool to push the images to the registry:
 
 ```sh
 export REGISTRY=myecr.domain.tld REGISTRY_NAMESPACE=myalfrescobuilds TARGETARCH=linux/amd64,linux/arm64
-docker buildx bake repo --set *.output=type=registry,push=true
+docker buildx bake repository --set *.output=type=registry,push=true
 ```
 
 ## Building specific ACS versions

--- a/README.md
+++ b/README.md
@@ -403,13 +403,23 @@ if the `grype` binary is available in the PATH.
 If you want to run the security scan manually, you can use the following command:
 
 ```sh
-make grype GRYPE_TARGET=repo GRYPE_OPTS="-f high --only-fixed --ignore-states wont-fix"
+make grype GRYPE_TARGET=repository GRYPE_OPTS="-f high --only-fixed --ignore-states wont-fix"
 ```
+
+`GRYPE_TARGET` accepts any `docker-bake.hcl` target or group name (e.g. `repository`,
+`share`, `community`, `enterprise`).
 
 You can pass `GRYPE_OPTS` to override the default options passed to Grype, which
 by default exit with a non-zero status if any vulnerability greater than high is
 found and is filtering out known issues for which a fix is not available (yet or
 ever).
+
+Set `GRYPE_OUTPUT_DIR` to write each image's scan output to a file in that directory
+instead of printing it to stdout, e.g. to collect SARIF reports for upload elsewhere:
+
+```sh
+make grype GRYPE_TARGET=repository GRYPE_OPTS="--only-fixed --ignore-states wont-fix -o sarif" GRYPE_OUTPUT_DIR=sarif
+```
 
 You can also run grype automatically at the end of the build process by setting
 `GRYPE_ONBUILD`:

--- a/README.md
+++ b/README.md
@@ -415,10 +415,11 @@ found and is filtering out known issues for which a fix is not available (yet or
 ever).
 
 Set `GRYPE_OUTPUT_DIR` to write each image's scan output to a file in that directory
-instead of printing it to stdout, e.g. to collect SARIF reports for upload elsewhere:
+instead of printing it to stdout, and `GRYPE_OUTPUT_FORMAT` to pick the format (see
+Grype's `-o`/`--output` flag), e.g. to collect SARIF reports for upload elsewhere:
 
 ```sh
-make grype GRYPE_TARGET=repository GRYPE_OPTS="--only-fixed --ignore-states wont-fix -o sarif" GRYPE_OUTPUT_DIR=sarif
+make grype GRYPE_TARGET=repository GRYPE_OPTS="--only-fixed --ignore-states wont-fix" GRYPE_OUTPUT_DIR=sarif GRYPE_OUTPUT_FORMAT=sarif
 ```
 
 You can also run grype automatically at the end of the build process by setting


### PR DESCRIPTION
## Summary
The `Grype scan` step in `test-make.yml` scans already-built images against the live vulnerability database on every PR/push, so a newly-disclosed CVE unrelated to the change fails unrelated PRs (e.g. https://github.com/Alfresco/alfresco-dockerfiles-bakery/actions/runs/30795209046/job/91627106584). This moves grype scanning out of that workflow and into a weekly (plus on-demand) scheduled workflow that scans all `make` targets and uploads results as SARIF to GitHub code scanning (GHAS) instead of failing the build.

- Removed the Install Grype / Add Grype to PATH / Grype scan steps from `test-make.yml`
- Added `.github/workflows/grype-scan.yml`: scheduled weekly (and `workflow_dispatch`), builds each `make` target, scans every resulting image with grype (via `make grype`, reusing the same Makefile logic as the manual/on-build scan path), and uploads results with `github/codeql-action/upload-sarif` under a per-image category so results show up in the repo's Security tab
- Extended the Makefile's `grype` target with `GRYPE_OUTPUT_DIR`/`GRYPE_OUTPUT_FORMAT` so the workflow can capture SARIF output per image instead of re-implementing the scan loop
- Renamed the Makefile's `repo` build target to `repository` to match the `docker-bake.hcl` target/group name it builds
- Dropped the redundant `community` target from the scan matrix: every image it builds is already covered by another target in the same matrix

## Test plan
- [ ] `Test make` workflow run is green without the grype step
- [ ] `Grype vulnerability scan` workflow (manually dispatched) completes and populates the Security > Code scanning tab with results per target

OPSEXP-3899