### PR TITLE
OPSEXP-4209 Ensure java_base system packages get refreshed periodically

### DIFF
--- a/.github/workflows/cleanup_images.yml
+++ b/.github/workflows/cleanup_images.yml
@@ -7,6 +7,14 @@ on:
     - cron: '0 19 */3 * *'  # Every 3 days after 7 PM
   workflow_dispatch:
     inputs:
+      job:
+        description: Which job to run (schedule always runs both)
+        type: choice
+        options:
+          - both
+          - cleanup
+          - expire-java-base-cache
+        default: both
       dry-run:
         description: Dry run (do not delete images)
         type: boolean
@@ -38,7 +46,7 @@ concurrency:
 
 jobs:
   cleanup:
-    if: github.actor != 'dependabot[bot]' && ! github.event.pull_request.head.repo.fork
+    if: github.actor != 'dependabot[bot]' && ! github.event.pull_request.head.repo.fork && (github.event_name != 'workflow_dispatch' || inputs.job != 'expire-java-base-cache')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -103,7 +111,7 @@ jobs:
           dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run || 'false' }}
 
   expire-java-base-cache:
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.job != 'cleanup')
     runs-on: ubuntu-latest
     steps:
       - name: Expire java_base cache tags to pick up latest OS package updates

--- a/.github/workflows/cleanup_images.yml
+++ b/.github/workflows/cleanup_images.yml
@@ -113,11 +113,13 @@ jobs:
   expire-java-base-cache:
     if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.job != 'cleanup')
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     steps:
       - name: Expire java_base cache tags to pick up latest OS package updates
         uses: dataaxiom/ghcr-cleanup-action@d52806a0dc70b430571a37da1fde39733ffd640f # v1.2.2
         with:
-          token: ${{ secrets.DELETE_PACKAGES_GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           owner: ${{ env.ORG }}
           repository: ${{ env.REPO }}
           packages: ${{ env.CACHE_REPO }}

--- a/.github/workflows/cleanup_images.yml
+++ b/.github/workflows/cleanup_images.yml
@@ -5,7 +5,6 @@ on:
     types: [closed]
   schedule:
     - cron: '0 19 */3 * *'  # Every 3 days after 7 PM
-    - cron: '0 4 * * 1'  # Weekly on Monday, to force a java_base cache refresh
   workflow_dispatch:
     inputs:
       dry-run:
@@ -90,18 +89,6 @@ jobs:
           older-than: ${{ env.PERIOD }}
           dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run || 'false' }}
 
-      - name: Expire java_base cache tags weekly to pick up latest OS package updates
-        uses: dataaxiom/ghcr-cleanup-action@d52806a0dc70b430571a37da1fde39733ffd640f # v1.2.2
-        if: github.event.schedule == '0 4 * * 1'
-        with:
-          token: ${{ secrets.DELETE_PACKAGES_GITHUB_TOKEN }}
-          owner: ${{ env.ORG }}
-          repository: ${{ env.REPO }}
-          packages: ${{ env.CACHE_REPO }}
-          delete-tags: '.*-java_base$'
-          use-regex: true
-          dry-run: false
-
       - name: Remove images when requested
         uses: dataaxiom/ghcr-cleanup-action@d52806a0dc70b430571a37da1fde39733ffd640f # v1.2.2
         if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
@@ -112,5 +99,20 @@ jobs:
           packages: ${{ env.PACKAGE_NAMES }},${{ env.CACHE_REPO }}
           delete-untagged: ${{ github.event_name == 'schedule' || inputs.untagged }}
           delete-tags: ${{ github.event.inputs.tags }}
+          use-regex: true
+          dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run || 'false' }}
+
+  expire-java-base-cache:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Expire java_base cache tags to pick up latest OS package updates
+        uses: dataaxiom/ghcr-cleanup-action@d52806a0dc70b430571a37da1fde39733ffd640f # v1.2.2
+        with:
+          token: ${{ secrets.DELETE_PACKAGES_GITHUB_TOKEN }}
+          owner: ${{ env.ORG }}
+          repository: ${{ env.REPO }}
+          packages: ${{ env.CACHE_REPO }}
+          delete-tags: '.*-java_base$'
           use-regex: true
           dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run || 'false' }}

--- a/.github/workflows/cleanup_images.yml
+++ b/.github/workflows/cleanup_images.yml
@@ -48,6 +48,8 @@ jobs:
   cleanup:
     if: github.actor != 'dependabot[bot]' && ! github.event.pull_request.head.repo.fork && (github.event_name != 'workflow_dispatch' || inputs.job != 'expire-java-base-cache')
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -75,7 +77,7 @@ jobs:
         env:
           PR_TAGS: ${{ format('pr-{0}*', github.event.pull_request.number) }}
         with:
-          token: ${{ secrets.DELETE_PACKAGES_GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           owner: ${{ env.ORG }}
           repository: ${{ env.REPO }}
           packages: ${{ env.PACKAGE_NAMES }}
@@ -88,7 +90,7 @@ jobs:
         env:
           PERIOD: ${{ inputs.cleanup-old-tags-period || '2 weeks' }}
         with:
-          token: ${{ secrets.DELETE_PACKAGES_GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           owner: ${{ env.ORG }}
           repository: ${{ env.REPO }}
           packages: ${{ env.PACKAGE_NAMES }},${{ env.CACHE_REPO }}
@@ -101,7 +103,7 @@ jobs:
         uses: dataaxiom/ghcr-cleanup-action@d52806a0dc70b430571a37da1fde39733ffd640f # v1.2.2
         if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         with:
-          token: ${{ secrets.DELETE_PACKAGES_GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           owner: ${{ env.ORG }}
           repository: ${{ env.REPO }}
           packages: ${{ env.PACKAGE_NAMES }},${{ env.CACHE_REPO }}

--- a/.github/workflows/cleanup_images.yml
+++ b/.github/workflows/cleanup_images.yml
@@ -5,6 +5,7 @@ on:
     types: [closed]
   schedule:
     - cron: '0 19 */3 * *'  # Every 3 days after 7 PM
+    - cron: '0 4 * * 1'  # Weekly on Monday, to force a java_base cache refresh
   workflow_dispatch:
     inputs:
       dry-run:
@@ -88,6 +89,18 @@ jobs:
           keep-n-tagged: 0
           older-than: ${{ env.PERIOD }}
           dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run || 'false' }}
+
+      - name: Expire java_base cache tags weekly to pick up latest OS package updates
+        uses: dataaxiom/ghcr-cleanup-action@d52806a0dc70b430571a37da1fde39733ffd640f # v1.2.2
+        if: github.event.schedule == '0 4 * * 1'
+        with:
+          token: ${{ secrets.DELETE_PACKAGES_GITHUB_TOKEN }}
+          owner: ${{ env.ORG }}
+          repository: ${{ env.REPO }}
+          packages: ${{ env.CACHE_REPO }}
+          delete-tags: '.*-java_base$'
+          use-regex: true
+          dry-run: false
 
       - name: Remove images when requested
         uses: dataaxiom/ghcr-cleanup-action@d52806a0dc70b430571a37da1fde39733ffd640f # v1.2.2

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -217,7 +217,6 @@ target "java_base" {
   tags = ["${REGISTRY}/${REGISTRY_NAMESPACE}/alfresco-base-java:${JDIST}${JAVA_MAJOR}-${DISTRIB_NAME}${DISTRIB_MAJOR}"]
   output = ["type=cacheonly"]
   platforms = split(",", "${TARGETARCH}")
-  no-cache-filter = ["rhlike"]
 }
 
 # Tomcat variables are set by makefile using tomcat/tomcat_versions.yaml

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -217,6 +217,7 @@ target "java_base" {
   tags = ["${REGISTRY}/${REGISTRY_NAMESPACE}/alfresco-base-java:${JDIST}${JAVA_MAJOR}-${DISTRIB_NAME}${DISTRIB_MAJOR}"]
   output = ["type=cacheonly"]
   platforms = split(",", "${TARGETARCH}")
+  no-cache-filter = ["rhlike"]
 }
 
 # Tomcat variables are set by makefile using tomcat/tomcat_versions.yaml


### PR DESCRIPTION
## Summary

CI's registry-backed build cache for the `java_base` bake target is keyed by branch/tag, and branches get rebuilt repeatedly under the same tag (e.g. every push to main/release triggers a rebuild with the same `${branch}-v${version}` tag). That meant the `rhlike` stage's `yum upgrade -y` layer in `java/Dockerfile` was being served from cache on repeat builds instead of re-running, silently skipping system package updates even though the Dockerfile's intent (since #178) is to always pull in the latest packages.

Simply disabling the build cache for that stage isn't a good option: `java_base` is consumed by `tomcat_base`, `search_liveindexing`, and `search_reindexing` as a real BuildKit `target:` context dependency, and everything downstream of those in turn, so busting its cache would cascade into full rebuilds of Tomcat, repository, share, and search images on every single push instead of only when their own Dockerfiles change.

Instead, this adds an `expire-java-base-cache` job to `.github/workflows/cleanup_images.yml` that periodically deletes just the `java_base` cache tags from the `bakery-cache` GHCR package (same schedule cadence as the existing cleanup job), forcing `yum upgrade` to re-run and pick up fresh packages at that cadence, while leaving the rest of the build cache untouched in between. It's a separate job so it can be triggered independently via `workflow_dispatch`, with a new `job` input to run just the cleanup job, just the cache expiry job, or both.

While testing the new job manually, it 403'd partway through untagging when using the existing `DELETE_PACKAGES_GITHUB_TOKEN` PAT. Swapping to the injected `GITHUB_TOKEN` with explicit `packages: write` permission resolved it, so both jobs in the workflow now use the default token instead of the hardcoded PAT.

## Test plan

- [x] `docker buildx bake --print java_base` to confirm the bake config parses cleanly
- [x] Built `java_base` locally to confirm the Dockerfile itself is unchanged and builds correctly
- [x] Manually triggered `expire-java-base-cache` via `workflow_dispatch` on this branch; confirmed it completes successfully with the `GITHUB_TOKEN` swap

OPSEXP-4209