### PR TITLE
Tag each Docker image with its artifact version instead of generic "latest"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ endif
 ifdef BAKE_NO_PROVENANCE
 DOCKER_BAKE_ARGS += --provenance=false
 endif
+	@echo "REGISTRY=$(if $(REGISTRY),$(REGISTRY),localhost) REGISTRY_NAMESPACE=$(if $(REGISTRY_NAMESPACE),$(REGISTRY_NAMESPACE),alfresco) TAG=$(if $(TAG),$(TAG),<none, tags come from artifact versions>)"
 
 auth:
 ifeq ($(REGISTRY),localhost)

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ help:
 ACS_VERSION ?= 26
 APS_VERSION ?= 26
 export ACS_VERSION
+export APS_VERSION
 export ARTIFACT_VERSIONS := $(shell python3 ./scripts/print_artifact_versions.py)
 
 setenv: auth

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ help:
 ACS_VERSION ?= 26
 APS_VERSION ?= 26
 export ACS_VERSION
+export ARTIFACT_VERSIONS := $(shell python3 ./scripts/print_artifact_versions.py)
 
 setenv: auth
 ifdef BAKE_NO_CACHE
@@ -74,7 +75,7 @@ clean_caches:
 	@echo "Cleaning up Docker cache"
 	docker builder prune -f
 	@echo "Cleaning up Artifacts cache"
-	find artifacts_cache/ ! -name .gitkeep -mindepth 1 -delete
+	find artifacts_cache/ -mindepth 1 ! -name .gitkeep -delete
 
 ## PREPARE TARGETS
 ## Keep targets in alphabetical order (following the folder structure)

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -75,7 +75,16 @@ variable "TARGETARCH" {
 }
 
 variable "TAG" {
-  default = "latest"
+  default = ""
+}
+
+variable "ARTIFACT_VERSIONS" {
+  default = "{}"
+}
+
+function "image_tag" {
+  params = [artifact]
+  result = TAG != "" ? TAG : lookup(jsondecode(ARTIFACT_VERSIONS), artifact, "latest")
 }
 
 variable "LABEL_VENDOR" {
@@ -289,7 +298,7 @@ target "repository" {
     "org.opencontainers.image.title" = "${PRODUCT_LINE} Content Repository (${repository_editions.name})"
     "org.opencontainers.image.description" = "Alfresco Content Services Repository ${repository_editions.name} edition"
   }
-  tags = ["${REGISTRY}/${REGISTRY_NAMESPACE}/${repository_editions.image_name}:${TAG}"]
+  tags = ["${REGISTRY}/${REGISTRY_NAMESPACE}/${repository_editions.image_name}:${image_tag(repository_editions.artifact)}"]
   output = ["type=docker"]
   platforms = split(",", "${TARGETARCH}")
 
@@ -368,7 +377,7 @@ target "search_liveindexing" {
     "org.opencontainers.image.title" = "${PRODUCT_LINE} Enterprise Search - ${liveindexing.name}"
     "org.opencontainers.image.description" = "${PRODUCT_LINE} Enterprise Search - ${liveindexing.name} live indexing"
   }
-  tags = ["${REGISTRY}/${REGISTRY_NAMESPACE}/${liveindexing.artifact}:${TAG}"]
+  tags = ["${REGISTRY}/${REGISTRY_NAMESPACE}/${liveindexing.artifact}:${image_tag(liveindexing.artifact)}"]
   output = ["type=docker"]
   platforms = split(",", "${TARGETARCH}")
 }
@@ -399,7 +408,7 @@ target "search_reindexing" {
     "org.opencontainers.image.title" = "${PRODUCT_LINE} Enterprise Search - reindexing"
     "org.opencontainers.image.description" = "${PRODUCT_LINE} Enterprise Search - reindexing component"
   }
-  tags = ["${REGISTRY}/${REGISTRY_NAMESPACE}/alfresco-elasticsearch-reindexing:${TAG}"]
+  tags = ["${REGISTRY}/${REGISTRY_NAMESPACE}/alfresco-elasticsearch-reindexing:${image_tag("alfresco-elasticsearch-reindexing")}"]
   output = ["type=docker"]
   platforms = split(",", "${TARGETARCH}")
 }
@@ -430,7 +439,7 @@ target "ats_trouter" {
     "org.opencontainers.image.title" = "${PRODUCT_LINE} ATS Trouter"
     "org.opencontainers.image.description" = "Alfresco Transform Service Trouter"
   }
-  tags = ["${REGISTRY}/${REGISTRY_NAMESPACE}/alfresco-transform-router:${TAG}"]
+  tags = ["${REGISTRY}/${REGISTRY_NAMESPACE}/alfresco-transform-router:${image_tag("alfresco-transform-router")}"]
   output = ["type=docker"]
   platforms = split(",", "${TARGETARCH}")
 }
@@ -461,7 +470,7 @@ target "ats_sfs" {
     "org.opencontainers.image.title" = "${PRODUCT_LINE} ATS Shared File Store"
     "org.opencontainers.image.description" = "Alfresco Transform Service ATS Shared File Store"
   }
-  tags = ["${REGISTRY}/${REGISTRY_NAMESPACE}/alfresco-shared-file-store:${TAG}"]
+  tags = ["${REGISTRY}/${REGISTRY_NAMESPACE}/alfresco-shared-file-store:${image_tag("alfresco-shared-file-store-controller")}"]
   output = ["type=docker"]
   platforms = split(",", "${TARGETARCH}")
 }
@@ -492,7 +501,7 @@ target "tengine_imagemagick" {
     "org.opencontainers.image.title" = "${PRODUCT_LINE} Transform Engine Imagemagick"
     "org.opencontainers.image.description" = "Alfresco Transform Engine Imagemagick"
   }
-  tags = ["${REGISTRY}/${REGISTRY_NAMESPACE}/alfresco-imagemagick:${TAG}"]
+  tags = ["${REGISTRY}/${REGISTRY_NAMESPACE}/alfresco-imagemagick:${image_tag("alfresco-transform-imagemagick")}"]
   output = ["type=docker"]
   platforms = split(",", "${TARGETARCH}")
 }
@@ -523,7 +532,7 @@ target "tengine_libreoffice" {
     "org.opencontainers.image.title" = "${PRODUCT_LINE} Transform Engine LibreOffice"
     "org.opencontainers.image.description" = "Alfresco Transform Engine LibreOffice"
   }
-  tags = ["${REGISTRY}/${REGISTRY_NAMESPACE}/alfresco-libreoffice:${TAG}"]
+  tags = ["${REGISTRY}/${REGISTRY_NAMESPACE}/alfresco-libreoffice:${image_tag("alfresco-transform-libreoffice")}"]
   output = ["type=docker"]
   platforms = split(",", "${TARGETARCH}")
 }
@@ -554,7 +563,7 @@ target "tengine_misc" {
     "org.opencontainers.image.title" = "${PRODUCT_LINE} Transform Engine Misc"
     "org.opencontainers.image.description" = "Alfresco Transform Engine Misc"
   }
-  tags = ["${REGISTRY}/${REGISTRY_NAMESPACE}/alfresco-transform-misc:${TAG}"]
+  tags = ["${REGISTRY}/${REGISTRY_NAMESPACE}/alfresco-transform-misc:${image_tag("alfresco-transform-misc")}"]
   output = ["type=docker"]
   platforms = split(",", "${TARGETARCH}")
 }
@@ -585,7 +594,7 @@ target "tengine_tika" {
     "org.opencontainers.image.title" = "${PRODUCT_LINE} Transform Engine Tika"
     "org.opencontainers.image.description" = "Alfresco Transform Engine Tika"
   }
-  tags = ["${REGISTRY}/${REGISTRY_NAMESPACE}/alfresco-tika:${TAG}"]
+  tags = ["${REGISTRY}/${REGISTRY_NAMESPACE}/alfresco-tika:${image_tag("alfresco-transform-tika")}"]
   output = ["type=docker"]
   platforms = split(",", "${TARGETARCH}")
 }
@@ -616,7 +625,7 @@ target "tengine_pdfrenderer" {
     "org.opencontainers.image.title" = "${PRODUCT_LINE} Transform Engine PDF Renderer"
     "org.opencontainers.image.description" = "Alfresco Transform Engine PDF Renderer"
   }
-  tags = ["${REGISTRY}/${REGISTRY_NAMESPACE}/alfresco-pdf-renderer:${TAG}"]
+  tags = ["${REGISTRY}/${REGISTRY_NAMESPACE}/alfresco-pdf-renderer:${image_tag("alfresco-pdf-renderer-jar")}"]
   output = ["type=docker"]
   platforms = split(",", "${TARGETARCH}")
 }
@@ -647,7 +656,7 @@ target "tengine_aio" {
     "org.opencontainers.image.title" = "${PRODUCT_LINE} Transform Engine All In One"
     "org.opencontainers.image.description" = "Alfresco Transform Engine All In One"
   }
-  tags = ["${REGISTRY}/${REGISTRY_NAMESPACE}/alfresco-transform-core-aio:${TAG}"]
+  tags = ["${REGISTRY}/${REGISTRY_NAMESPACE}/alfresco-transform-core-aio:${image_tag("alfresco-transform-core-aio")}"]
   output = ["type=docker"]
   platforms = split(",", "${TARGETARCH}")
 }
@@ -678,7 +687,7 @@ target "connector_msteams" {
     "org.opencontainers.image.title" = "${PRODUCT_LINE} Connector Microsoft Teams"
     "org.opencontainers.image.description" = "Alfresco Connector Microsoft Teams"
   }
-  tags = ["${REGISTRY}/${REGISTRY_NAMESPACE}/alfresco-ms-teams-service:${TAG}"]
+  tags = ["${REGISTRY}/${REGISTRY_NAMESPACE}/alfresco-ms-teams-service:${image_tag("alfresco-ms-teams-springboot")}"]
   output = ["type=docker"]
   platforms = split(",", "${TARGETARCH}")
 }
@@ -709,7 +718,7 @@ target "connector_ms365" {
     "org.opencontainers.image.title" = "${PRODUCT_LINE} Microsoft 365 Connector"
     "org.opencontainers.image.description" = "Alfresco Microsoft 365 Connector"
   }
-  tags = ["${REGISTRY}/${REGISTRY_NAMESPACE}/alfresco-ooi-service:${TAG}"]
+  tags = ["${REGISTRY}/${REGISTRY_NAMESPACE}/alfresco-ooi-service:${image_tag("onedrive-springboot")}"]
   output = ["type=docker"]
   platforms = split(",", "${TARGETARCH}")
 }
@@ -741,7 +750,7 @@ target "share" {
     "org.opencontainers.image.title" = "${PRODUCT_LINE} Share"
     "org.opencontainers.image.description" = "Alfresco Share"
   }
-  tags = ["${REGISTRY}/${REGISTRY_NAMESPACE}/${share_editions.image_name}:${TAG}"]
+  tags = ["${REGISTRY}/${REGISTRY_NAMESPACE}/${share_editions.image_name}:${image_tag(share_editions.artifact)}"]
   output = ["type=docker"]
   platforms = split(",", "${TARGETARCH}")
 
@@ -794,7 +803,7 @@ target "search_service" {
     "org.opencontainers.image.title" = "${PRODUCT_LINE} Search Service (Solr)"
     "org.opencontainers.image.description" = "Alfresco Search Service (Solr)"
   }
-  tags = ["${REGISTRY}/${REGISTRY_NAMESPACE}/alfresco-search-service:${TAG}"]
+  tags = ["${REGISTRY}/${REGISTRY_NAMESPACE}/alfresco-search-service:${image_tag("alfresco-search-services")}"]
   output = ["type=docker"]
   platforms = split(",", "${TARGETARCH}")
 }
@@ -807,7 +816,7 @@ target "acc" {
     "org.opencontainers.image.title" = "${PRODUCT_LINE} Control Center"
     "org.opencontainers.image.description" = "Alfresco Control Center"
   }
-  tags = ["${REGISTRY}/${REGISTRY_NAMESPACE}/alfresco-control-center:${TAG}"]
+  tags = ["${REGISTRY}/${REGISTRY_NAMESPACE}/alfresco-control-center:${image_tag("alfresco-control-center")}"]
   output = ["type=docker"]
   platforms = split(",", "${TARGETARCH}")
 }
@@ -820,7 +829,7 @@ target "adw" {
     "org.opencontainers.image.title" = "${PRODUCT_LINE} Digital Workspace"
     "org.opencontainers.image.description" = "Alfresco Digital Workspace"
   }
-  tags = ["${REGISTRY}/${REGISTRY_NAMESPACE}/alfresco-digital-workspace:${TAG}"]
+  tags = ["${REGISTRY}/${REGISTRY_NAMESPACE}/alfresco-digital-workspace:${image_tag("alfresco-digital-workspace")}"]
   output = ["type=docker"]
   platforms = split(",", "${TARGETARCH}")
 }
@@ -851,7 +860,7 @@ target "sync" {
     "org.opencontainers.image.title" = "${PRODUCT_LINE} Sync Service"
     "org.opencontainers.image.description" = "Alfresco Sync Service"
   }
-  tags = ["${REGISTRY}/${REGISTRY_NAMESPACE}/alfresco-sync-service:${TAG}"]
+  tags = ["${REGISTRY}/${REGISTRY_NAMESPACE}/alfresco-sync-service:${image_tag("sync-distribution")}"]
   output = ["type=docker"]
   platforms = split(",", "${TARGETARCH}")
 }
@@ -882,7 +891,7 @@ target "audit_storage" {
     "org.opencontainers.image.title" = "${PRODUCT_LINE} repository's Audit Storage"
     "org.opencontainers.image.description" = "Alfresco Audit Storage for repository events"
   }
-  tags = ["${REGISTRY}/${REGISTRY_NAMESPACE}/alfresco-audit-storage:${TAG}"]
+  tags = ["${REGISTRY}/${REGISTRY_NAMESPACE}/alfresco-audit-storage:${image_tag("alfresco-audit-storage-app")}"]
   output = ["type=docker"]
   platforms = split(",", "${TARGETARCH}")
 }
@@ -913,7 +922,7 @@ target "hxinsight_connector_bulk_ingester" {
     "org.opencontainers.image.title" = "${PRODUCT_LINE} repository's HxInsight Connector Bulk Ingester"
     "org.opencontainers.image.description" = "Alfresco HxInsight Connector Bulk Ingester"
   }
-  tags = ["${REGISTRY}/${REGISTRY_NAMESPACE}/alfresco-hxinsight-connector-bulk-ingester:${TAG}"]
+  tags = ["${REGISTRY}/${REGISTRY_NAMESPACE}/alfresco-hxinsight-connector-bulk-ingester:${image_tag("alfresco-hxinsight-connector-bulk-ingester")}"]
   output = ["type=docker"]
   platforms = split(",", "${TARGETARCH}")
 }
@@ -936,7 +945,7 @@ target "hxinsight_connector_live_ingester" {
     "org.opencontainers.image.title" = "${PRODUCT_LINE} repository's HxInsight Connector Live Ingester"
     "org.opencontainers.image.description" = "Alfresco HxInsight Connector Live Ingester"
   }
-  tags = ["${REGISTRY}/${REGISTRY_NAMESPACE}/alfresco-hxinsight-connector-live-ingester:${TAG}"]
+  tags = ["${REGISTRY}/${REGISTRY_NAMESPACE}/alfresco-hxinsight-connector-live-ingester:${image_tag("alfresco-hxinsight-connector-live-ingester")}"]
   output = ["type=docker"]
   platforms = split(",", "${TARGETARCH}")
 }
@@ -959,7 +968,7 @@ target "hxinsight_connector_prediction_applier" {
     "org.opencontainers.image.title" = "${PRODUCT_LINE} repository's HxInsight Connector Prediction Applier"
     "org.opencontainers.image.description" = "Alfresco HxInsight Connector Prediction Applier"
   }
-  tags = ["${REGISTRY}/${REGISTRY_NAMESPACE}/alfresco-hxinsight-connector-prediction-applier:${TAG}"]
+  tags = ["${REGISTRY}/${REGISTRY_NAMESPACE}/alfresco-hxinsight-connector-prediction-applier:${image_tag("alfresco-hxinsight-connector-prediction-applier")}"]
   output = ["type=docker"]
   platforms = split(",", "${TARGETARCH}")
 }
@@ -989,7 +998,7 @@ target "aps-admin" {
     "org.opencontainers.image.title" = "${PRODUCT_LINE} Process Services Admin"
     "org.opencontainers.image.description" = "Alfresco Process Services Admin Console"
   }
-  tags = ["${REGISTRY}/${REGISTRY_NAMESPACE}/alfresco-process-services-admin:${TAG}"]
+  tags = ["${REGISTRY}/${REGISTRY_NAMESPACE}/alfresco-process-services-admin:${image_tag("alfresco-process-services-admin")}"]
   output = ["type=docker"]
   platforms = split(",", "${TARGETARCH}")
 }
@@ -1016,7 +1025,7 @@ target "aps-app" {
     "org.opencontainers.image.title" = "${PRODUCT_LINE} Process Services App"
     "org.opencontainers.image.description" = "Alfresco Process Services App"
   }
-  tags = ["${REGISTRY}/${REGISTRY_NAMESPACE}/alfresco-process-services:${TAG}"]
+  tags = ["${REGISTRY}/${REGISTRY_NAMESPACE}/alfresco-process-services:${image_tag("alfresco-process-services-app")}"]
   output = ["type=docker"]
   platforms = split(",", "${TARGETARCH}")
 }

--- a/scripts/print_artifact_versions.py
+++ b/scripts/print_artifact_versions.py
@@ -23,14 +23,16 @@ def main():
 
     versions = {}
     for pattern in patterns:
-        for file_path in glob.glob(pattern, recursive=True):
+        for file_path in sorted(glob.glob(pattern, recursive=True)):
             with open(file_path, "r", encoding="utf-8") as yaml_file:
                 data = yaml.safe_load(yaml_file)
             artifacts = data.get("artifacts", {})
             for name, details in artifacts.items():
-                versions[name] = details.get("version")
+                version = details.get("version")
+                if version is not None:
+                    versions[name] = version
 
-    print(json.dumps(versions))
+    print(json.dumps(versions, sort_keys=True))
 
 if __name__ == "__main__":
     main()

--- a/scripts/print_artifact_versions.py
+++ b/scripts/print_artifact_versions.py
@@ -12,25 +12,27 @@ import os
 import yaml
 
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+APS_ROOT = os.path.join(REPO_ROOT, "aps")
 ACS_VERSION = os.getenv("ACS_VERSION", "26")
 APS_VERSION = os.getenv("APS_VERSION", "26")
 
 def main():
-    patterns = [
-        os.path.join(REPO_ROOT, "**", f"artifacts-{ACS_VERSION}.yaml"),
-        os.path.join(REPO_ROOT, "aps", "**", f"artifacts-{APS_VERSION}.yaml"),
+    acs_files = [
+        file_path
+        for file_path in glob.glob(os.path.join(REPO_ROOT, "**", f"artifacts-{ACS_VERSION}.yaml"), recursive=True)
+        if not file_path.startswith(APS_ROOT + os.sep)
     ]
+    aps_files = glob.glob(os.path.join(APS_ROOT, "**", f"artifacts-{APS_VERSION}.yaml"), recursive=True)
 
     versions = {}
-    for pattern in patterns:
-        for file_path in sorted(glob.glob(pattern, recursive=True)):
-            with open(file_path, "r", encoding="utf-8") as yaml_file:
-                data = yaml.safe_load(yaml_file)
-            artifacts = data.get("artifacts", {})
-            for name, details in artifacts.items():
-                version = details.get("version")
-                if version is not None:
-                    versions[name] = version
+    for file_path in sorted(acs_files) + sorted(aps_files):
+        with open(file_path, "r", encoding="utf-8") as yaml_file:
+            data = yaml.safe_load(yaml_file)
+        artifacts = data.get("artifacts", {})
+        for name, details in artifacts.items():
+            version = details.get("version")
+            if version is not None:
+                versions[name] = version
 
     print(json.dumps(versions, sort_keys=True))
 

--- a/scripts/print_artifact_versions.py
+++ b/scripts/print_artifact_versions.py
@@ -1,0 +1,36 @@
+"""
+Collect the version of every artifact declared across the artifacts yaml files
+and print them as a single JSON map of {artifact_name: version}.
+
+Run this script with:
+python3 scripts/print_artifact_versions.py
+"""
+
+import glob
+import json
+import os
+import yaml
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+ACS_VERSION = os.getenv("ACS_VERSION", "26")
+APS_VERSION = os.getenv("APS_VERSION", "26")
+
+def main():
+    patterns = [
+        os.path.join(REPO_ROOT, "**", f"artifacts-{ACS_VERSION}.yaml"),
+        os.path.join(REPO_ROOT, "aps", "**", f"artifacts-{APS_VERSION}.yaml"),
+    ]
+
+    versions = {}
+    for pattern in patterns:
+        for file_path in glob.glob(pattern, recursive=True):
+            with open(file_path, "r", encoding="utf-8") as yaml_file:
+                data = yaml.safe_load(yaml_file)
+            artifacts = data.get("artifacts", {})
+            for name, details in artifacts.items():
+                versions[name] = details.get("version")
+
+    print(json.dumps(versions))
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_print_artifact_versions.bats
+++ b/scripts/tests/test_print_artifact_versions.bats
@@ -1,0 +1,85 @@
+#!/usr/bin/env bats
+
+setup() {
+    export SCRIPT_DIR="$BATS_TEST_DIRNAME/.."
+    export SCRIPT="$SCRIPT_DIR/print_artifact_versions.py"
+    export ACTUAL_REPO_ROOT="$SCRIPT_DIR/.."
+
+    export TEST_TOPLEVEL_DIR="$ACTUAL_REPO_ROOT/bats_pav_test"
+    export TEST_APS_DIR="$ACTUAL_REPO_ROOT/aps/bats_pav_test"
+
+    export ACS_VERSION="999"
+    export APS_VERSION="998"
+}
+
+teardown() {
+    rm -rf "$TEST_TOPLEVEL_DIR" "$TEST_APS_DIR"
+}
+
+@test "script exists and is readable" {
+    [ -f "$SCRIPT" ]
+    [ -r "$SCRIPT" ]
+}
+
+@test "script runs and prints valid JSON" {
+    cd "$ACTUAL_REPO_ROOT"
+    run python3 "$SCRIPT"
+    [ "$status" -eq 0 ]
+    echo "$output" | python3 -c "import json,sys; json.loads(sys.stdin.read())"
+}
+
+@test "script picks up top-level artifacts for ACS_VERSION" {
+    mkdir -p "$TEST_TOPLEVEL_DIR"
+    cat > "$TEST_TOPLEVEL_DIR/artifacts-999.yaml" << 'EOF'
+artifacts:
+  bats-toplevel-artifact:
+    version: "1.2.3"
+EOF
+
+    cd "$ACTUAL_REPO_ROOT"
+    run python3 "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"bats-toplevel-artifact": "1.2.3"'* ]]
+}
+
+@test "script picks up aps/ artifacts for APS_VERSION" {
+    mkdir -p "$TEST_APS_DIR"
+    cat > "$TEST_APS_DIR/artifacts-998.yaml" << 'EOF'
+artifacts:
+  bats-aps-artifact:
+    version: "4.5.6"
+EOF
+
+    cd "$ACTUAL_REPO_ROOT"
+    run python3 "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"bats-aps-artifact": "4.5.6"'* ]]
+}
+
+@test "script excludes aps/ directory when scanning for ACS_VERSION" {
+    mkdir -p "$TEST_APS_DIR"
+    cat > "$TEST_APS_DIR/artifacts-999.yaml" << 'EOF'
+artifacts:
+  bats-aps-should-be-excluded:
+    version: "9.9.9"
+EOF
+
+    cd "$ACTUAL_REPO_ROOT"
+    run python3 "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"bats-aps-should-be-excluded"* ]]
+}
+
+@test "script skips artifacts with a missing version" {
+    mkdir -p "$TEST_TOPLEVEL_DIR"
+    cat > "$TEST_TOPLEVEL_DIR/artifacts-999.yaml" << 'EOF'
+artifacts:
+  bats-no-version-artifact:
+    name: bats-no-version-artifact
+EOF
+
+    cd "$ACTUAL_REPO_ROOT"
+    run python3 "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"bats-no-version-artifact"* ]]
+}


### PR DESCRIPTION
## Problem

Every image built by `docker-bake.hcl` was tagged with a single global `TAG` variable that defaults to `latest`, so there was no way to tell which version of the underlying Alfresco component (repository, share, transform engines, connectors, ADF apps, etc.) actually shipped inside a given image without inspecting the build args or the image contents.

Originally raised in https://github.com/Alfresco/alfresco-dockerfiles-bakery/pull/361

## Approach

A single `ARTIFACT_VERSIONS` variable carries a JSON map of `{artifactName: version}` into bake, and a new `image_tag(artifact)` HCL function looks up the version for the Maven artifactId each target already declares in its build args (artifact name and Maven artifactId are the same thing, so the lookup is unambiguous). `TAG` still overrides every image uniformly when set explicitly, which preserves the existing CI behavior of stamping a release tag across the board; when `TAG` is empty, `image_tag()` falls back to the artifact's real version, or to `latest` if the artifact happens to be missing from the map.

`scripts/print_artifact_versions.py` walks every `artifacts-{ACS_VERSION}.yaml` (plus `aps/**/artifacts-{APS_VERSION}.yaml`, since APS uses its own version variable) and prints the resulting `{name: version}` map as JSON. The `Makefile` exports `ARTIFACT_VERSIONS` from this script near the existing `ACS_VERSION`/`APS_VERSION` block, so every `docker buildx bake` invocation picks it up automatically without any per-target logic.

Because tags now key off the matrix's own artifact rather than a single global value, the community and enterprise editions of `repository`/`share` and each `search_liveindexing` variant automatically get their own correct individual versions.

Also included a small pre-existing fix in `clean_caches`: `find artifacts_cache/ ! -name .gitkeep -mindepth 1 -delete` had `-mindepth 1` placed after the name exclusion, which meant it never actually applied; reordered to `find artifacts_cache/ -mindepth 1 ! -name .gitkeep -delete`.

## Test plan

- [x] `ACS_VERSION=26 python3 scripts/print_artifact_versions.py | python3 -m json.tool` produces valid JSON containing every artifact key referenced from `docker-bake.hcl`
- [x] `docker buildx bake -f docker-bake.hcl --print repository share search_enterprise` with `ARTIFACT_VERSIONS` set shows each edition/variant resolving to its own real component version (e.g. `alfresco-content-repository-community:26.1.0`, `alfresco-elasticsearch-live-indexing-metadata:5.6.0`)
- [x] `TAG=1.2.3 docker buildx bake -f docker-bake.hcl --print repository` shows every tag ending in `:1.2.3`
- [x] `docker buildx bake -f docker-bake.hcl --print` (plus `hxinsight_connector` and `aps` groups, which aren't in the default group) shows every image resolving to a concrete component version, with nothing falling back to `latest`
