### PR TITLE
OPSEXP-4209 Pin community search backend to Solr in tests

### DIFF
--- a/test/community-override.yaml
+++ b/test/community-override.yaml
@@ -1,7 +1,34 @@
 # Do not move this file to a folder that is not a first level folder
+# Upstream community-compose.yaml now defaults to the batch-indexing/Elasticsearch
+# search backend; this override restores Solr until batch-indexing is supported here.
 services:
   alfresco:
     image: ${REGISTRY}/${REGISTRY_NAMESPACE}/alfresco-content-repository-community:${TAG}
+    environment:
+      JAVA_OPTS: >-
+        -Ddb.driver=org.postgresql.Driver
+        -Ddb.username=alfresco
+        -Ddb.password=alfresco
+        -Ddb.url=jdbc:postgresql://postgres:5432/alfresco
+        -Dsolr.host=solr6
+        -Dsolr.port=8983
+        -Dsolr.secureComms=secret
+        -Dsolr.sharedSecret=secret
+        -Dsolr.base.url=/solr
+        -Dindex.subsystem.name=solr6
+        -Dshare.host=localhost
+        -Dshare.port=8080
+        -Dalfresco.host=localhost
+        -Dalfresco.port=8080
+        -Dcsrf.filter.enabled=false
+        -Daos.baseUrlOverwrite=http://localhost:8080/alfresco/aos
+        -Dmessaging.broker.url="failover:(nio://activemq:61616)?timeout=3000&jms.useCompression=true"
+        -Dmessaging.broker.username=admin
+        -Dmessaging.broker.password=admin
+        -Ddeployment.method=DOCKER_COMPOSE
+        -DlocalTransform.core-aio.url=http://transform-core-aio:8090/
+        -XX:MinRAMPercentage=50
+        -XX:MaxRAMPercentage=80
   transform-core-aio:
     image: ${REGISTRY}/${REGISTRY_NAMESPACE}/alfresco-transform-core-aio:${TAG}
   share:
@@ -21,3 +48,15 @@ services:
       BASE_PATH: /
     volumes:
       - ./configs/acc.json:/usr/share/nginx/html/app.config.json
+  # Scaled to zero rather than removed: Compose merge has no plain-YAML way to
+  # drop a service key (the `!reset` tag that would do it isn't valid YAML to
+  # our check-yaml pre-commit hook).
+  elasticsearch:
+    deploy:
+      replicas: 0
+  kibana:
+    deploy:
+      replicas: 0
+  batch-indexing:
+    deploy:
+      replicas: 0

--- a/test/helm/test-overrides-community.yaml
+++ b/test/helm/test-overrides-community.yaml
@@ -1,4 +1,16 @@
 ---
+# Upstream community_values.yaml now defaults to the batch-indexing/Elasticsearch
+# search backend; these overrides restore Solr until batch-indexing is supported here.
+# https://alfresco.github.io/acs-deployment/docs/helm/examples/search-services.html
+global:
+  search:
+    flavor: solr6
+elasticsearch:
+  enabled: false
+alfresco-search:
+  enabled: true
+alfresco-search-community:
+  enabled: false
 alfresco-digital-workspace:
   enabled: false
 alfresco-sync-service:
@@ -20,6 +32,9 @@ dtas:
 alfresco-repository:
   startupProbe:
     initialDelaySeconds: 120
+  configuration:
+    search:
+      flavor: solr6
 alfresco-transform-service:
   pdfrenderer:
     livenessProbe:


### PR DESCRIPTION
## Summary

Upstream `acs-deployment` (pinned to `v10.7.0` via `.github/actions/acs-deployment`, the latest tag) switched ACS Community's default search backend from Solr to the new batch-indexing/Elasticsearch stack: `community-compose.yaml` dropped the `solr6` service in favour of `elasticsearch`/`kibana`/`batch-indexing`, and `community_values.yaml` flips `alfresco-search-community.enabled` to `true` with `alfresco-search.enabled: false` and no `elasticsearch.enabled: false` override. We don't yet support testing against batch-indexing here, so both the compose and Helm community test paths were silently exercising the new backend instead of Solr since the ref bump to `v10.7.0`.

This restores Solr for community edition testing only, following the pattern from https://alfresco.github.io/acs-deployment/docs/helm/examples/search-services.html for Helm and adapting the `solr6-overrides.yaml` idea (that file only matches the `search`/`search-reindexing` service names used by the Enterprise compose family) for the community compose file:

- `test/community-override.yaml`: reverts `alfresco`'s `JAVA_OPTS` to the Solr-flavoured settings, and scales `elasticsearch`/`kibana`/`batch-indexing` to zero replicas so they never start (the `!reset` tag that would otherwise drop these services outright isn't valid YAML as far as the repo's `check-yaml` pre-commit hook is concerned).
- `test/helm/test-overrides-community.yaml`: sets `global.search.flavor` and `alfresco-repository.configuration.search.flavor` to `solr6`, enables `alfresco-search`, and disables `alfresco-search-community` and the embedded `elasticsearch` cluster.

## Test plan

- [x] Validated both override files as valid YAML and pass the repo's `check-yaml` pre-commit hook
- [x] Merged `test/community-override.yaml` against upstream `v10.7.0`'s `community-compose.yaml` locally with `docker compose config` and confirmed `alfresco` gets the Solr `JAVA_OPTS`, `solr6` is present, and `elasticsearch`/`kibana`/`batch-indexing` are scaled to zero replicas
- [x] CI `helm-test` and `compose-test` jobs for the `community` edition pass end to end