### PR TITLE
Prune stale artifact versions on fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,11 @@ then fetch correct version with e.g.:
 make clean prepare ACS_VERSION=23
 ```
 
+Superseded versions of an artifact are also pruned automatically from its
+target folder as soon as the new version is fetched, so re-running with a
+different `ACS_VERSION` (or after bumping a version in an `artifacts-XX.yaml`
+file) without `make clean` first will not leave stale files behind.
+
 Artifacts set in the artifacts file are fetched from the Nexus repository and
 their checksum is verified, provided the artifact has a checksum value which is
 a concatenation of the algorithm and optionally the checksum in the format

--- a/scripts/fetch_artifacts.py
+++ b/scripts/fetch_artifacts.py
@@ -11,6 +11,7 @@ import argparse
 import logging
 import netrc
 import os
+import re
 import shutil
 import sys
 import tempfile
@@ -28,6 +29,7 @@ class ChecksumMismatchError(Exception):
 # Constants
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 TEMP_DIR = tempfile.mkdtemp()
+FETCHED_ARTIFACTS = set()
 ACS_VERSION = os.getenv("ACS_VERSION", "26")
 MAVEN_FQDN = os.getenv("MAVEN_FQDN", "nexus.alfresco.com")
 MAVEN_REPO = os.getenv("MAVEN_REPO", f"https://{MAVEN_FQDN}/nexus/repository")
@@ -79,6 +81,113 @@ def get_checksums(artifact_checksum, artifact_url, artifact_file_path):
     return checksum, computed_checksum
 
 
+def artifact_filename(artifact_details):
+    """
+    Build the versioned file name for an artifact, e.g. postgresql-42.7.10.jar
+    """
+    artifact_name = artifact_details.get("name")
+    artifact_version = artifact_details.get("version")
+    artifact_ext = artifact_details.get("classifier", "")
+    return f"{artifact_name}-{artifact_version}{artifact_ext}"
+
+def prune_stale_artifacts(artifact_details, current_final_path):
+    """
+    Remove previously downloaded versions of this artifact from its target folder
+    """
+    artifact_dir = artifact_details.get("path")
+    if not os.path.isdir(artifact_dir):
+        return
+
+    artifact_name = artifact_details.get("name")
+    artifact_ext = artifact_details.get("classifier", "")
+    current_basename = os.path.basename(current_final_path)
+    # the version segment must start with a digit, so name prefixes like
+    # alfresco-elasticsearch-live-indexing vs -content/-metadata/... don't collide
+    pattern = re.compile(re.escape(artifact_name) + r"-\d[^" + re.escape(os.sep) + r"]*" + re.escape(artifact_ext))
+
+    for entry in os.listdir(artifact_dir):
+        entry_path = os.path.join(artifact_dir, entry)
+        if entry == current_basename or entry_path in FETCHED_ARTIFACTS:
+            continue
+        if os.path.isfile(entry_path) and pattern.fullmatch(entry):
+            os.remove(entry_path)
+            logger.info(f"Removing stale artifact {entry_path} (superseded by {current_basename})")
+
+def fetch_artifact(artifact_details):
+    """
+    Download a single artifact from the Alfresco Nexus repository, using the cache when possible.
+    Returns True if the wanted version ends up at its final path, False if the fetch was skipped.
+    """
+    artifact_repo = artifact_details.get("repository")
+    artifact_name = artifact_details.get("name")
+    artifact_version = artifact_details.get("version")
+    artifact_ext = artifact_details.get("classifier", "")
+    artifact_checksum = artifact_details.get("checksum")
+    artifact_group = artifact_details.get("group")
+    artifact_path = artifact_details.get("path")
+
+    artifact_basename = artifact_filename(artifact_details)
+    artifact_baseurl = f"{MAVEN_REPO}/{artifact_repo}"
+    artifact_tmp_path = os.path.join(TEMP_DIR, artifact_basename)
+    artifact_cache_path = os.path.join(REPO_ROOT, "artifacts_cache", artifact_basename)
+    artifact_final_path = os.path.join(artifact_path, artifact_basename)
+    artifact_url = f"{artifact_baseurl}/{artifact_group.replace('.', '/')}/{artifact_name}/{artifact_version}/{artifact_basename}"
+
+    # Check if the artifact is already present
+    if os.path.isfile(artifact_final_path):
+        logger.info(f"Artifact {artifact_name}-{artifact_version} already present.")
+        src_checksum, computed_checksum = get_checksums(artifact_checksum, artifact_url, artifact_final_path)
+        if not src_checksum and not computed_checksum:
+            logger.info('No valid checksum found, skipping verification...')
+            return True
+        if src_checksum == computed_checksum:
+            logger.info(f"Checksum matched for {artifact_basename}")
+            return True
+        logger.info(f"Checksum mismatch for {artifact_basename}. Re-downloading...")
+        os.remove(artifact_final_path)
+
+    if os.path.isfile(artifact_cache_path):
+        src_checksum, computed_checksum = get_checksums(artifact_checksum, artifact_url, artifact_cache_path)
+        if src_checksum == computed_checksum:
+            logger.info(f"Artifact {artifact_name}-{artifact_version} already present in cache, copying...")
+            shutil.copy(artifact_cache_path, artifact_final_path)
+            return True
+        else:
+            logger.info(f"Checksum mismatch for {artifact_basename}. Re-downloading...")
+            os.remove(artifact_cache_path)
+
+    # Download the artifact
+    logger.info(f"Downloading {artifact_group}:{artifact_name} {artifact_version} from {artifact_baseurl}")
+    try:
+        with urllib.request.urlopen(artifact_url) as response, open(artifact_tmp_path, 'wb') as out_file:
+            shutil.copyfileobj(response, out_file)
+
+        checksums = get_checksums(
+            artifact_checksum, artifact_url,
+            artifact_tmp_path
+        )
+        if checksums[0] != checksums[1]:
+            raise ChecksumMismatchError(
+                f"Checksum mismatch for {artifact_basename}."
+                f"Expected: {checksums[0]}, Computed: {checksums[1]}"
+            )
+
+    except urllib.error.HTTPError as e:
+        if e.code == 401:
+            logger.warning("Invalid or missing credentials, skipping...")
+            return False
+        elif e.code == 403:
+            logger.warning("Forbidden access, skipping...")
+            return False
+        else:
+            # rethrow the exception to exit with failure
+            raise e
+
+    # Move to cache and copy to final path
+    shutil.move(artifact_tmp_path, artifact_cache_path)
+    shutil.copy(artifact_cache_path, artifact_final_path)
+    return True
+
 def do_parse_and_mvn_fetch(file_path):
     """
     Parse the artifacts yaml file and download the artifacts from the Alfresco Nexus repository
@@ -87,76 +196,12 @@ def do_parse_and_mvn_fetch(file_path):
         data = yaml.safe_load(yaml_file)
         artifacts = data.get("artifacts", {})
 
-    for artifact_name, artifact_details in artifacts.items():
-        artifact_repo = artifact_details.get("repository")
-        artifact_name = artifact_details.get("name")
-        artifact_version = artifact_details.get("version")
-        artifact_ext = artifact_details.get("classifier", "")
-        artifact_checksum = artifact_details.get("checksum")
-        artifact_group = artifact_details.get("group")
-        artifact_path = artifact_details.get("path")
-
-        artifact_baseurl = f"{MAVEN_REPO}/{artifact_repo}"
-        artifact_tmp_path = os.path.join(TEMP_DIR, f"{artifact_name}-{artifact_version}{artifact_ext}")
-        artifact_cache_path = os.path.join(REPO_ROOT, "artifacts_cache", f"{artifact_name}-{artifact_version}{artifact_ext}")
-        artifact_final_path = os.path.join(artifact_path, f"{artifact_name}-{artifact_version}{artifact_ext}")
-        artifact_url = f"{artifact_baseurl}/{artifact_group.replace('.', '/')}/{artifact_name}/{artifact_version}/{artifact_name}-{artifact_version}{artifact_ext}"
-
+    for artifact_details in artifacts.values():
         logger.info("")
-
-        # Check if the artifact is already present
-        if os.path.isfile(artifact_final_path):
-            logger.info(f"Artifact {artifact_name}-{artifact_version} already present.")
-            src_checksum, computed_checksum = get_checksums(artifact_checksum, artifact_url, artifact_final_path)
-            if not src_checksum and not computed_checksum:
-                logger.info('No valid checksum found, skipping verification...')
-                continue
-            if src_checksum == computed_checksum:
-                logger.info(f"Checksum matched for {artifact_name}-{artifact_version}{artifact_ext}")
-                continue
-            logger.info(f"Checksum mismatch for {artifact_name}-{artifact_version}{artifact_ext}. Re-downloading...")
-            os.remove(artifact_final_path)
-
-        if os.path.isfile(artifact_cache_path):
-            src_checksum, computed_checksum = get_checksums(artifact_checksum, artifact_url, artifact_cache_path)
-            if src_checksum == computed_checksum:
-                logger.info(f"Artifact {artifact_name}-{artifact_version} already present in cache, copying...")
-                shutil.copy(artifact_cache_path, artifact_final_path)
-                continue
-            else:
-                logger.info(f"Checksum mismatch for {artifact_name}-{artifact_version}{artifact_ext}. Re-downloading...")
-                os.remove(artifact_cache_path)
-
-        # Download the artifact
-        logger.info(f"Downloading {artifact_group}:{artifact_name} {artifact_version} from {artifact_baseurl}")
-        try:
-            with urllib.request.urlopen(artifact_url) as response, open(artifact_tmp_path, 'wb') as out_file:
-                shutil.copyfileobj(response, out_file)
-
-            checksums = get_checksums(
-                artifact_checksum, artifact_url,
-                artifact_tmp_path
-            )
-            if checksums[0] != checksums[1]:
-                raise ChecksumMismatchError(
-                    f"Checksum mismatch for {artifact_name}-{artifact_version}{artifact_ext}."
-                    f"Expected: {checksums[0]}, Computed: {checksums[1]}"
-                )
-
-        except urllib.error.HTTPError as e:
-            if e.code == 401:
-                logger.warning("Invalid or missing credentials, skipping...")
-                continue
-            elif e.code == 403:
-                logger.warning("Forbidden access, skipping...")
-                continue
-            else:
-                # rethrow the exception to exit with failure
-                raise e
-
-        # Move to cache and copy to final path
-        shutil.move(artifact_tmp_path, artifact_cache_path)
-        shutil.copy(artifact_cache_path, artifact_final_path)
+        if fetch_artifact(artifact_details):
+            artifact_final_path = os.path.join(artifact_details.get("path"), artifact_filename(artifact_details))
+            prune_stale_artifacts(artifact_details, artifact_final_path)
+            FETCHED_ARTIFACTS.add(artifact_final_path)
 
 def arg_is_glob_pattern(arg):
     """

--- a/scripts/tests/test_fetch_artifacts.bats
+++ b/scripts/tests/test_fetch_artifacts.bats
@@ -163,3 +163,81 @@ EOF
     [[ "$output" != *"WARNING:"* ]]
     [[ "$output" != *"ERROR:"* ]]
 }
+
+@test "script removes stale version of an artifact after fetching the current one" {
+    export ACS_VERSION="25"
+
+    mkdir -p "$ACTUAL_REPO_ROOT/bats_test"
+    touch "$ACTUAL_REPO_ROOT/bats_test/test-artifact-1.0.0.jar"
+    touch "$ACTUAL_REPO_ROOT/bats_test/test-artifact-2.0.0.jar"
+
+    cat > "$ACTUAL_REPO_ROOT/bats_test/artifacts-25.yaml" << 'EOF'
+artifacts:
+  test-artifact:
+    name: test-artifact
+    version: 2.0.0
+    classifier: .jar
+    repository: public
+    group: com.test
+    path: bats_test
+EOF
+
+    cd "$ACTUAL_REPO_ROOT"
+    run python3 scripts/fetch_artifacts.py bats_test --log-level DEBUG
+    echo "Output: $output"
+
+    [[ "$output" == *"Removing stale artifact"* ]] && [[ "$output" == *"test-artifact-1.0.0.jar"* ]]
+    [ ! -f "$ACTUAL_REPO_ROOT/bats_test/test-artifact-1.0.0.jar" ]
+    [ -f "$ACTUAL_REPO_ROOT/bats_test/test-artifact-2.0.0.jar" ]
+}
+
+@test "script does not remove a differently-named artifact sharing a name prefix" {
+    export ACS_VERSION="25"
+
+    mkdir -p "$ACTUAL_REPO_ROOT/bats_test"
+    touch "$ACTUAL_REPO_ROOT/bats_test/test-artifact-1.0.0.jar"
+    touch "$ACTUAL_REPO_ROOT/bats_test/test-artifact-2.0.0.jar"
+    touch "$ACTUAL_REPO_ROOT/bats_test/test-artifact-extra-1.0.0.jar"
+
+    cat > "$ACTUAL_REPO_ROOT/bats_test/artifacts-25.yaml" << 'EOF'
+artifacts:
+  test-artifact:
+    name: test-artifact
+    version: 2.0.0
+    classifier: .jar
+    repository: public
+    group: com.test
+    path: bats_test
+EOF
+
+    cd "$ACTUAL_REPO_ROOT"
+    run python3 scripts/fetch_artifacts.py bats_test --log-level DEBUG
+    echo "Output: $output"
+
+    [ -f "$ACTUAL_REPO_ROOT/bats_test/test-artifact-extra-1.0.0.jar" ]
+}
+
+@test "script does not log a removal when no stale version is present" {
+    export ACS_VERSION="25"
+
+    mkdir -p "$ACTUAL_REPO_ROOT/bats_test"
+    touch "$ACTUAL_REPO_ROOT/bats_test/test-artifact-2.0.0.jar"
+
+    cat > "$ACTUAL_REPO_ROOT/bats_test/artifacts-25.yaml" << 'EOF'
+artifacts:
+  test-artifact:
+    name: test-artifact
+    version: 2.0.0
+    classifier: .jar
+    repository: public
+    group: com.test
+    path: bats_test
+EOF
+
+    cd "$ACTUAL_REPO_ROOT"
+    run python3 scripts/fetch_artifacts.py bats_test --log-level DEBUG
+    echo "Output: $output"
+
+    [[ "$output" != *"Removing stale artifact"* ]]
+    [ -f "$ACTUAL_REPO_ROOT/bats_test/test-artifact-2.0.0.jar" ]
+}


### PR DESCRIPTION
## Summary

When a version bump lands in an `artifacts-*.yaml` file, re-running `fetch_artifacts.py` downloads the new artifact but leaves the previous version's file in the same target folder, since the script only ever adds files and never removes superseded ones. Several Dockerfiles unpack "the" archive in a directory via a glob pattern expecting a single match, so leftover files from a prior version cause confusing build failures.

This adds a `prune_stale_artifacts` step that runs right after an artifact's current version is confirmed in place (freshly downloaded, copied from cache, or already present with a matching/absent checksum). It removes other files in the same target folder that match `<name>-<digit...><classifier>`, logging one line per removal, and never touches files it fetched earlier in the same run (needed because a single invocation can process multiple yaml files that legitimately want different versions of the same artifact in the same folder, e.g. via the `**/artifacts-25*.yaml` glob used in CI). The `<digit>` requirement after the name keeps distinct artifacts that share a name prefix apart, e.g. `alfresco-elasticsearch-live-indexing` vs `alfresco-elasticsearch-live-indexing-content` in `search/enterprise/common`. The `artifacts_cache/` folder is intentionally left alone, since it is deliberately multi-version and already covered by `make clean_caches`.

## Test plan

- [x] `bats -r --print-output-on-failure scripts/tests/test_fetch_artifacts.bats` passes, including three new cases: stale version removed, prefix-named sibling left untouched, no-op when nothing is stale
- [x] `python3 -m py_compile scripts/fetch_artifacts.py`
- [x] Manually verify against the real repo: `make prepare_repo && ACS_VERSION=25 make prepare_repo` should leave exactly one archive per folder with a `Removing stale artifact` log line for each superseded file