### PR TITLE
OPSEXP-4209 Migrate bumpVersions workflow to GitHub App authentication

### DIFF
--- a/.github/updatecli_amps.tpl
+++ b/.github/updatecli_amps.tpl
@@ -9,6 +9,7 @@ scms:
       branch: {{ .updatecli_amps_release_branch }}
       token: {{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}
       username: {{ requiredEnv "UPDATECLI_GITHUB_USERNAME" }}
+      commitusingapi: true
   acsEntRepo:
     kind: github
     spec:
@@ -17,6 +18,7 @@ scms:
       branch: {{ .updatecli_amps_release_branch }}
       token: {{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}
       username: {{ requiredEnv "UPDATECLI_GITHUB_USERNAME" }}
+      commitusingapi: true
   acsComRepo:
     kind: github
     spec:
@@ -25,6 +27,7 @@ scms:
       branch: {{ .updatecli_amps_release_branch }}
       token: {{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}
       username: {{ requiredEnv "UPDATECLI_GITHUB_USERNAME" }}
+      commitusingapi: true
 
 sources:
 {{- range $key, $artifact := .artifacts }}

--- a/.github/updatecli_dockerfile.tpl
+++ b/.github/updatecli_dockerfile.tpl
@@ -28,3 +28,4 @@ scms:
       username: {{ requiredEnv "UPDATECLI_GITHUB_USERNAME" }}
       user: {{ requiredEnv "UPDATECLI_GITHUB_USERNAME" }}
       email: {{ requiredEnv "UPDATECLI_GITHUB_EMAIL" }}
+      commitusingapi: true

--- a/.github/updatecli_tomcat.tpl
+++ b/.github/updatecli_tomcat.tpl
@@ -87,6 +87,7 @@ scms:
       username: {{ requiredEnv "UPDATECLI_GITHUB_USERNAME" }}
       user: {{ requiredEnv "UPDATECLI_GITHUB_USERNAME" }}
       email: {{ requiredEnv "UPDATECLI_GITHUB_EMAIL" }}
+      commitusingapi: true
   tomcat:
     kind: git
     spec:

--- a/.github/workflows/bumpVersions.yml
+++ b/.github/workflows/bumpVersions.yml
@@ -28,10 +28,6 @@ on:
   schedule:
     - cron: '0 6 * * 1'
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name || github.run_id }}
-  cancel-in-progress: true
-
 env:
   DEFAULT_BRANCH_NAME: main
 
@@ -42,6 +38,9 @@ jobs:
     if: |
       (inputs.update-type == 'artifacts' || github.event_name != 'workflow_dispatch') &&
       github.actor != 'dependabot[bot]'
+    concurrency:
+      group: ${{ github.workflow }}-build-${{ github.head_ref || github.ref_name }}
+      cancel-in-progress: true
     steps:
       - name: Generate app token
         id: app-token
@@ -103,6 +102,9 @@ jobs:
     if: |
       (inputs.update-type == 'tomcat' || github.event_name == 'schedule') &&
       github.actor != 'dependabot[bot]'
+    concurrency:
+      group: ${{ github.workflow }}-tomcats-${{ github.head_ref || github.ref_name }}
+      cancel-in-progress: true
     steps:
       - name: Generate app token
         id: app-token
@@ -139,6 +141,9 @@ jobs:
     if: |
       (inputs.update-type == 'dockerfile' || github.event_name == 'schedule') &&
       github.actor != 'dependabot[bot]'
+    concurrency:
+      group: ${{ github.workflow }}-dockerfile-${{ github.head_ref || github.ref_name }}
+      cancel-in-progress: true
     steps:
       - name: Generate app token
         id: app-token

--- a/.github/workflows/bumpVersions.yml
+++ b/.github/workflows/bumpVersions.yml
@@ -43,10 +43,17 @@ jobs:
       (inputs.update-type == 'artifacts' || github.event_name != 'workflow_dispatch') &&
       github.actor != 'dependabot[bot]'
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.GH_APP_ENGINEERING_CONTRIB_CLIENT_ID }}
+          private-key: ${{ secrets.GH_APP_ENGINEERING_CONTRIB_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          token: ${{ secrets.BOT_GITHUB_TOKEN || github.token }}
 
       - name: Install Updatecli
         uses: Alfresco/alfresco-build-tools/.github/actions/setup-updatecli@v18.21.1
@@ -72,20 +79,23 @@ jobs:
         env:
           NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME_READ_ONLY }}
           NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD_READ_ONLY }}
-          UPDATECLI_GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+          UPDATECLI_GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           UPDATECLI_GITHUB_USERNAME: ${{ vars.BOT_GITHUB_USERNAME}}
 
-      - name: Git Auto Commit
+      - name: Open pull request
         if: github.actor != 'dependabot[bot]'
-        uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7.2.0
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          commit_message: |
+          token: ${{ steps.app-token.outputs.token }}
+          base: main
+          branch: updatecli-bump-versions
+          draft: true
+          sign-commits: true
+          commit-message: |
             🛠 Updatecli pipeline artifacts bump
-          commit_user_name: ${{ vars.BOT_GITHUB_USERNAME }}
-          commit_user_email: ${{ vars.BOT_GITHUB_EMAIL }}
-          branch: ${{ github.ref_name == env.DEFAULT_BRANCH_NAME && 'updatecli-bump-versions' || github.ref_name }}
-          create_branch: ${{ github.ref_name == env.DEFAULT_BRANCH_NAME }}
-          push_options: ${{ github.ref_name == env.DEFAULT_BRANCH_NAME && '--force' || '' }}
+          title: 🛠 Updatecli pipeline artifacts bump
+          body: |
+            Updatecli pipeline artifacts bump.
 
   tomcats:
     runs-on: ubuntu-latest
@@ -94,6 +104,15 @@ jobs:
       (inputs.update-type == 'tomcat' || github.event_name == 'schedule') &&
       github.actor != 'dependabot[bot]'
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.GH_APP_ENGINEERING_CONTRIB_CLIENT_ID }}
+          private-key: ${{ secrets.GH_APP_ENGINEERING_CONTRIB_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -110,7 +129,7 @@ jobs:
 
       - run: updatecli pipeline apply -c .github/updatecli_tomcat.tpl
         env:
-          UPDATECLI_GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+          UPDATECLI_GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           UPDATECLI_GITHUB_USERNAME: ${{ vars.BOT_GITHUB_USERNAME }}
           UPDATECLI_GITHUB_EMAIL: ${{ vars.BOT_GITHUB_EMAIL }}
 
@@ -121,6 +140,15 @@ jobs:
       (inputs.update-type == 'dockerfile' || github.event_name == 'schedule') &&
       github.actor != 'dependabot[bot]'
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.GH_APP_ENGINEERING_CONTRIB_CLIENT_ID }}
+          private-key: ${{ secrets.GH_APP_ENGINEERING_CONTRIB_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -129,6 +157,6 @@ jobs:
 
       - run: updatecli pipeline apply -c .github/updatecli_dockerfile.tpl
         env:
-          UPDATECLI_GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+          UPDATECLI_GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           UPDATECLI_GITHUB_USERNAME: ${{ vars.BOT_GITHUB_USERNAME }}
           UPDATECLI_GITHUB_EMAIL: ${{ vars.BOT_GITHUB_EMAIL }}


### PR DESCRIPTION
## Summary

Replaces the `BOT_GITHUB_TOKEN` PAT and `stefanzweifel/git-auto-commit-action` in `bumpVersions.yml` with a GitHub App installation token (`actions/create-github-app-token`), generated in each of the three jobs (`build`, `tomcats`, `dockerfile`). For the `build` job, which previously committed directly via `git-auto-commit-action`, the commit step is now `peter-evans/create-pull-request` (draft PR to `main`, branch `updatecli-bump-versions`), since we're moving away from direct pushes. The `tomcats` and `dockerfile` jobs only needed the token swapped in `UPDATECLI_GITHUB_TOKEN`, since updatecli's own `github/pullrequest` action already opens the PR for those.

Also enabled `commitusingapi: true` on every `kind: github` scm block across the updatecli manifests (`updatecli_amps.tpl`, `updatecli_tomcat.tpl`, `updatecli_dockerfile.tpl`) so updatecli commits through the GitHub API using the installation token instead of local git, which is what's needed for GitHub App tokens to work correctly. `updatecli.tpl` has no scm block and was left untouched.

## Test plan

- [x] Confirm `vars.GH_APP_ENGINEERING_CONTRIB_CLIENT_ID` / `secrets.GH_APP_ENGINEERING_CONTRIB_PRIVATE_KEY` are configured for this repo and the app installation has `contents: write` + `pull-requests: write`
- [x] Manually trigger `workflow_dispatch` for each of `artifacts` / `tomcat` / `dockerfile` update types and confirm a draft PR is opened (or updated) by the app
- [ ] Confirm commits in the resulting PR are authored by the GitHub App, not the old bot PAT identity

OPSEXP-4209