### PR TITLE
OPSEXP-4209 Remove outdated ADF release note

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,7 +511,6 @@ For authentication check out [nexus authentication](#nexus-authentication)
 - Run the [updatecli
   workflow](https://github.com/Alfresco/alfresco-dockerfiles-bakery/actions/workflows/bumpVersions.yml)
   and review the changes.
-- Review and manually update the `adf` [images](adf-apps) as they are not yet supported in updatecli workflow
 - Merge all the eventual dependabot and updatecli PRs (for nginx and tomcat base
   images)
 - Agree on a name for the release and make sure to add it to the release notes.


### PR DESCRIPTION
## Summary
- Removes the README release-checklist bullet about manually reviewing/updating `adf` images, since they are now handled by the updatecli workflow.

OPSEXP-4209