### PR TITLE
Proposal: make the repository image extensible without forking

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,112 @@
+# Alfresco Dockerfiles Bakery
+
+Builds the Alfresco platform container images (ACS, APS, ATS, search, connectors, ADF apps) from
+release artifacts pulled off Alfresco's Nexus. There is no application source here — only
+Dockerfiles, entrypoints, artifact manifests and the bake/make plumbing that assembles them.
+
+## Commands
+
+```sh
+make help                       # list build targets
+make enterprise                 # or: community, all, repository, share, aps, tengines, ...
+make enterprise ACS_VERSION=23  # build an older line (see Versioning below)
+make clean prepare ACS_VERSION=23   # always clean before switching versions
+make clean_caches               # prune docker builder cache + artifacts_cache/
+
+docker buildx bake tengine_imagemagick   # single image, bypassing make (no auth/fetch wrapper)
+docker buildx bake repository --print    # resolved target config, useful for debugging HCL
+
+bats -r --print-output-on-failure .              # full bats suite (as CI runs it)
+bats scripts/tests/test_fetch_artifacts.bats     # single test file
+pre-commit run --all-files                       # yaml/json/workflow-schema + checkmake
+
+make grype GRYPE_TARGET=repository GRYPE_OPTS="-f high --only-fixed"
+make all GRYPE_ONBUILD=1        # scan every image at the end of the build
+```
+
+Nexus credentials come from `~/.netrc` (`machine nexus.alfresco.com`, mode 0600) or
+`NEXUS_USERNAME`/`NEXUS_PASSWORD`. Without them, Enterprise artifacts are skipped with a warning
+rather than failing the run, so a "successful" build can silently be missing images.
+
+Build env vars: `REGISTRY` (default `localhost`), `REGISTRY_NAMESPACE` (`alfresco`), `TAG`,
+`TARGETARCH` (comma-separated list for multi-arch — requires pushing to a registry),
+`BAKE_NO_CACHE`, `BAKE_NO_PROVENANCE`.
+
+## Architecture
+
+**`docker-bake.hcl` is the source of truth.** It declares every image target, its build context,
+args, OCI labels and tags. The `Makefile` is a wrapper that adds three things bake cannot do:
+registry login (with an interactive confirmation prompt), fetching artifacts before the build, and
+optional Grype scanning. Each `make <component>` target therefore pairs a `prepare_<component>`
+(fetch) with a `docker buildx bake <component>`.
+
+**Two-phase build.** `scripts/fetch_artifacts.py` reads every `artifacts-<VERSION>.yaml`, downloads
+each artifact from Nexus into the `path:` declared in the manifest (e.g. `repository/amps`,
+`repository/distribution`), verifies the checksum, caches it in `artifacts_cache/`, and prunes
+superseded versions of the same artifact from the target folder. The Dockerfiles then pull those
+files into the build. All downloaded binaries are gitignored — the folders under each component
+contain only a placeholder `README.md`.
+
+**Build inputs as named contexts.** `repository` reads each of its build inputs through a named
+context (`repo_distribution`, `repo_amps`, `repo_amps_edition`, `repo_libs`, `repo_simple_modules`)
+declared in `docker-bake.hcl`, defaulting to the folder it replaces and consumed with
+`COPY --from=<context> / <dest>`. A consumer can then repoint an input at a directory of their own
+with `cwd://` and build against a remote bake definition, so customizing an image needs no fork of
+this repository. Overriding a context *replaces* that folder rather than merging with it. The other
+components still `COPY` straight from their own build context; converting them follows the
+`repository` pattern.
+
+**Base image chain.** `java_base` (`./java`) → `tomcat_base` (`./tomcat`) → webapp images
+(`repository`, `share`, `aps-*`). Everything else inherits `java_base` directly. Both bases are
+`output = ["type=cacheonly"]` and are wired in as named build contexts
+(`contexts = { java_base = "target:java_base" }`), which is why component Dockerfiles start with
+`FROM java_base` / `FROM tomcat_base` — those are bake contexts, not registry images, and such a
+Dockerfile cannot be built with plain `docker build`.
+
+**Distro dispatch.** Dockerfiles select the final stage through arg interpolation:
+`FROM <name>-rhlike AS ...` / `FROM <name>-rockylinux9` / `FROM <name>-${DISTRIB_NAME}${DISTRIB_MAJOR}`.
+Adding OS support means adding a stage alias, not branching in `RUN`.
+
+**Versioning.** `ACS_VERSION` (default 26) and `APS_VERSION` pick which `artifacts-XX.yaml` files
+are read, for both fetching and tagging. `docker-bake.hcl` derives the rest from `ACS_VERSION`:
+`select_java_version` and `select_tomcat_field` map 23/25 → Java 17 + Tomcat 10, anything else →
+Java 21 + Tomcat 11. Tomcat versions and SHA512s live in the `TOMCAT_VERSIONS` map in the HCL.
+
+**Tags come from artifact versions, not `latest`.** The Makefile exports `ARTIFACT_VERSIONS`, a JSON
+map produced by `scripts/print_artifact_versions.py`, and the `image_tag(artifact)` HCL function
+looks the version up per target. Setting `TAG` overrides this for all images.
+
+## Conventions
+
+- Every service runs as a dedicated non-root user; the numeric UID/GID are `variable` blocks in
+  `docker-bake.hcl` (shared `ALFRESCO_GROUP_ID` 1000, per-service UIDs in the 330xx range) passed
+  through as build args. Keep them stable — they are load-bearing for volume permissions.
+- Spring Boot services ship a two-line `entrypoint.sh`: `exec java $JAVA_OPTS
+  $JAVA_OPTS_CONTAINER_FLAGS -jar /opt/app.jar`.
+- `artifacts-XX.yaml` entries need `name`, `version`, `group`, `repository` (Nexus repo:
+  `public`/`releases`/`enterprise-releases`), `path` (destination dir), `classifier` (the file
+  extension, e.g. `".jar"`), and `checksum` as `<algo>:` — leaving the hash empty makes the script
+  fetch `<url>.<algo>` from Nexus.
+- Automated version bumps are driven by updatecli (`.github/updatecli*.tpl`, weekly
+  `bumpVersions.yml`). An artifact is only bumped if it has an `updatecli_matrix_component_key`
+  entry in `.github/updatecli_values.yaml`; AMP bumps additionally need
+  `updatecli_amps_release_branch` in the manifest.
+- Adding a component: create the folder (Dockerfile, `entrypoint.sh`, `artifacts-XX.yaml` per
+  supported version), add a `target` and put it in the right `group` in `docker-bake.hcl`, declare
+  its build inputs as named contexts, add a `prepare_<x>` and a build target in the `Makefile` (both
+  blocks are kept alphabetical), and add it to the `test-make.yml` matrix.
+- Named context names, target names, build args and UIDs are the interface consumers build against.
+  Renaming one breaks overlays that never appear in this repository.
+- `checkmake` caps Makefile recipe bodies at 22 lines (`checkmake.ini`); factor longer logic into
+  `scripts/`.
+- Dockerfile findings suppressed on purpose are listed with a rationale in `kics.config`; Grype
+  ignores `java-archive` packages (`.grype.yaml`) because the focus is base-OS CVEs.
+
+## CI
+
+`build_and_test.yml` runs pre-commit, then a matrix of ACS 26/25/23 and APS 26/25/24 through the
+reusable workflows, each of which bakes the images to ghcr.io and then validates them twice: a
+docker compose run driven by a Postman collection, and a Helm install into KinD (amd64 + arm64)
+followed by `helm test`. Compose files and Helm values are pulled from the `acs-deployment` repo at
+runtime; only the override files in `test/` are versioned here. `test-make.yml` separately checks
+that each `make` target still builds and loads images locally.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+@.github/copilot-instructions.md

--- a/README.md
+++ b/README.md
@@ -154,19 +154,23 @@ make all
 
 ### Customizing the Alfresco Content Repository image
 
-The Alfresco Content Repository image can be customized by adding files into
-specific folders:
+The Alfresco Content Repository image reads its build inputs from named build
+contexts, each defaulting to a folder of this repository:
 
-- Alfresco Module Packages (AMPs) files in the [amps](repository/amps/README.md)
-  folder for both Enterprise and Community editions
-  - For Enterprise-only AMPs files in the
-    [amps-enterprise](repository/amps_enterprise/README.md) folder
-  - For Community-only AMPs files in the
-    [amps-community](repository/amps_community/README.md) folder
-- Simple Module (JAR) files in the
-  [simple_modules](repository/simple_modules/README.md) folder
-- Additional JAR files for the JRE in the [libs](repository/libs/README.md)
-  folder
+| Context | Default | Holds |
+| --- | --- | --- |
+| `repo_distribution` | `repository/distribution` | ACS distribution zip |
+| `repo_amps` | `repository/amps` | AMPs for both editions |
+| `repo_amps_edition` | `repository/amps_<edition>` | Edition specific AMPs |
+| `repo_libs` | `repository/libs` | JARs added to the Tomcat lib directory |
+| `repo_simple_modules` | `repository/simple_modules` | Simple module JARs |
+
+Customizing the image is a matter of repointing the contexts you care about at
+directories of your own, from a git repository of your own. Your AMPs, simple
+modules and extra JARs then live outside of this repository, which is consumed
+straight from git, so upgrading to a newer Bakery release never involves
+reconciling a merge. See the [repository
+README](repository/README.md#customizing-the-image) for the full procedure.
 
 ### Customizing the Share image
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -284,6 +284,13 @@ target "repository" {
   inherits = ["tomcat_base"]
   contexts = {
     tomcat_base = "target:tomcat_base"
+    # Build inputs are named contexts so they can be repointed at a local
+    # directory (cwd://...) without forking this repository.
+    repo_distribution   = "./repository/distribution"
+    repo_amps           = "./repository/amps"
+    repo_amps_edition   = "./repository/amps_${repository_editions.name}"
+    repo_libs           = "./repository/libs"
+    repo_simple_modules = "./repository/simple_modules"
   }
   args = {
     ALFRESCO_REPO_GROUP_ID = "${ALFRESCO_GROUP_ID}"
@@ -291,7 +298,6 @@ target "repository" {
     ALFRESCO_REPO_USER_ID = "${ALFRESCO_REPO_USER_ID}"
     ALFRESCO_REPO_USER_NAME = "${ALFRESCO_REPO_USER_NAME}"
     ALFRESCO_REPO_ARTIFACT = "${repository_editions.artifact}"
-    ALFRESCO_REPO_EDITION = "${repository_editions.name}"
   }
   labels = {
     "org.label-schema.name" = "${PRODUCT_LINE} Content Repository (${repository_editions.name})"

--- a/repository/Dockerfile
+++ b/repository/Dockerfile
@@ -6,12 +6,11 @@ ARG ALFRESCO_REPO_GROUP_ID
 FROM tomcat_base AS repo_build
 
 ARG ALFRESCO_REPO_ARTIFACT
-ARG ALFRESCO_REPO_EDITION
 
 USER root
 RUN yum install -y unzip
 
-COPY distribution/${ALFRESCO_REPO_ARTIFACT}-*.zip /tmp/
+COPY --from=repo_distribution ${ALFRESCO_REPO_ARTIFACT}-*.zip /tmp/
 ENV DISTDIR="/tmp/distribution"
 
 RUN unzip /tmp/*.zip -d ${DISTDIR}
@@ -31,9 +30,9 @@ RUN sed -i \
   -re "s|(appender.rolling.filePattern=)(alfresco.log.%d\{yyyy-MM-dd\})|\1${CATALINA_HOME}/logs\/\2|" \
   ${CATALINA_HOME}/webapps/alfresco/WEB-INF/classes/log4j*.properties
 
-COPY amps /tmp/amps
-COPY amps_${ALFRESCO_REPO_EDITION} /tmp/amps
-COPY libs ${CATALINA_HOME}/lib/
+COPY --from=repo_amps / /tmp/amps
+COPY --from=repo_amps_edition / /tmp/amps
+COPY --from=repo_libs / ${CATALINA_HOME}/lib/
 RUN if [ -f /tmp/amps/alfresco-aos-module-*.amp ]; then umask 0027; \
      unzip ${DISTDIR}/web-server/webapps/ROOT.war -d ${CATALINA_HOME}/webapps/ROOT/; \
      cp ${CATALINA_HOME}/webapps/ROOT/META-INF/context.xml ${CATALINA_HOME}/conf/Catalina/localhost/ROOT.xml; \
@@ -44,7 +43,7 @@ RUN java -jar ${DISTDIR}/bin/alfresco-mmt.jar install \
     /tmp/amps/ ${CATALINA_HOME}/webapps/alfresco -nobackup -directory -force && \
     java -jar ${DISTDIR}/bin/alfresco-mmt.jar list ${CATALINA_HOME}/webapps/alfresco
 
-COPY simple_modules /tmp/simple_modules
+COPY --from=repo_simple_modules / /tmp/simple_modules
 RUN mkdir -m 750 -p ${CATALINA_HOME}/modules/platform && \
     for jar in /tmp/simple_modules/*.jar; do \
       if [ -f "$jar" ]; then \

--- a/repository/README.md
+++ b/repository/README.md
@@ -78,6 +78,67 @@ git repository.
 > leaves you reconciling conflicts on every upgrade. Prefer repointing the
 > contexts above.
 
+## Extending the image
+
+Repointing a context covers what the image is built *from*. Anything else, such
+as an OS package, an internal CA certificate or an extra configuration file, is
+added by building an image of your own on top of the one this repository
+produces, in the same bake invocation.
+
+Reference the target you want to extend as a named context, from a target of
+your own:
+
+```hcl
+target "repository_acme" {
+  context = "cwd://custom/repository"
+  contexts = {
+    bakery = "target:repository_enterprise"
+  }
+  tags = ["myregistry.domain.tld/alfresco-content-repository:26.2.1-acme1"]
+  labels = {
+    "org.opencontainers.image.title" = "Acme Alfresco Content Repository"
+    "org.opencontainers.image.vendor" = "Acme Corp"
+    "org.opencontainers.image.source" = "https://github.com/acme/my-alfresco-images"
+  }
+}
+```
+
+Then write your own Dockerfile in `custom/repository`, starting from that
+context:
+
+```dockerfile
+FROM bakery
+
+USER root
+RUN yum install -y acme-agent && yum clean all && rm -rf /var/cache/yum
+COPY acme-ca.crt /etc/pki/ca-trust/source/anchors/
+RUN update-ca-trust extract
+USER alfresco
+```
+
+Build it by naming your own target:
+
+```bash
+docker buildx bake \
+  "https://github.com/Alfresco/alfresco-dockerfiles-bakery.git#v0.14.0" \
+  -f cwd://docker-bake.hcl repository_acme
+```
+
+Three things to keep in mind:
+
+- The image runs as the unprivileged `alfresco` user. Switch to `root` for the
+  steps that need it and switch back at the end, or your image starts as root.
+- Labels are inherited from the base image, so without the `labels` block above
+  your image reports Hyland as its vendor and this repository as its source.
+  Override them so that your image describes itself.
+- Files you add belong to `root` and miss the ownership pass applied while the
+  base image is assembled. Give them the `alfresco` group when the repository
+  has to read them.
+
+Because this adds a layer on top of a finished image, it cannot change what the
+image already contains: a file removed this way still ships in the layer
+underneath, where image scanners will not report it.
+
 ## Running the image
 
 ### Alfresco repository configuration

--- a/repository/README.md
+++ b/repository/README.md
@@ -6,17 +6,77 @@ This Docker file is used to build an Alfresco Content Repository image.
 
 ## Building the image
 
-Make sure all required artifacts are present in the build context `repository/`.
-You can put them manually in the `repository/` folder (for example if that's a
-custom module of yours), or use the script `./scripts/fetch-artifacts.py` to
-download them from Alfresco's Nexus.
-
-Then, you can build the image from the root of this git repository with the
-following command:
+The Alfresco artifacts this image is built from are downloaded from Alfresco's
+Nexus by `./scripts/fetch_artifacts.py` into the `repository/` sub folders.
+From the root of this git repository:
 
 ```bash
-docker buildx bake repository
+make repository
 ```
+
+## Customizing the image
+
+Customizations belong in a git repository of your own. You need neither a clone
+nor a fork of this one: this repository is consumed straight from git, so
+upgrading never involves reconciling a merge. A minimal layout:
+
+```tree
+my-alfresco-images/
+|_docker-bake.hcl
+|_my-jdbc-drivers/
+  |_postgresql-42.7.10.jar
+```
+
+The build inputs are read from named build contexts, each defaulting to the
+folder it replaces in this repository:
+
+| Context | Default | Holds |
+| --- | --- | --- |
+| `repo_distribution` | `repository/distribution` | ACS distribution zip |
+| `repo_amps` | `repository/amps` | AMPs for both editions |
+| `repo_amps_edition` | `repository/amps_<edition>` | Edition specific AMPs |
+| `repo_libs` | `repository/libs` | JARs added to the Tomcat lib directory |
+| `repo_simple_modules` | `repository/simple_modules` | Simple module JARs |
+
+Your `docker-bake.hcl` holds your overrides only. Repoint the contexts you need
+and set the tag your image should be published under:
+
+```hcl
+target "repository_enterprise" {
+  contexts = {
+    repo_libs = "cwd://my-jdbc-drivers"
+  }
+  tags = ["myregistry.domain.tld/alfresco-content-repository:26.2.1-acme1"]
+}
+```
+
+Everything else, this repository's targets included, comes from the definition
+you build against:
+
+```bash
+docker buildx bake \
+  "https://github.com/Alfresco/alfresco-dockerfiles-bakery.git#v0.14.0" \
+  -f cwd://docker-bake.hcl repository_enterprise
+```
+
+Upgrading to a newer Bakery release is a matter of changing that git ref, so
+pin it to a release rather than to a branch.
+
+Contexts are merged per key, so the ones you leave out keep their defaults. A
+context you do override is *replaced*, not merged: your directory becomes the
+entire content of that build input. Overriding `repo_libs` as above drops the
+PostgreSQL JDBC driver this repository ships, and overriding `repo_amps` drops
+`alfresco-share-services`, which Share needs. When you override a context, put
+in it everything that build input is expected to hold, not only your own files.
+
+`cwd://` is required for paths that are local to your own repository. Without
+it, a relative path is resolved against the build context, which is the remote
+git repository.
+
+> **Deprecated**: copying your own files directly into the `repository/*`
+> folders of a clone still works, but it requires a fork of this repository and
+> leaves you reconciling conflicts on every upgrade. Prefer repointing the
+> contexts above.
 
 ## Running the image
 

--- a/repository/amps/README.md
+++ b/repository/amps/README.md
@@ -1,7 +1,12 @@
 # Alfresco repository AMPs
 
-Place here your Alfresco module Packages (AMPs) to be installed in the Alfresco
-repository.
+This folder is the default content of the `repo_amps` build context: the
+Alfresco Module Packages (AMPs) installed in the repository image for both
+editions.
+
+To ship AMPs of your own, repoint `repo_amps` at a directory of your own rather
+than adding files here, which would require a fork of this repository. See
+[customizing the image](../README.md#customizing-the-image).
 
 AMP packages should have the `.amp` extension and stick to the Alfresco module
 packaging format as described in the [Alfresco documentation][amp].
@@ -13,13 +18,14 @@ The [in-process Alfresco SDK][sdk] provides a way to build well structured AMPs.
 > use the [out-of-process Alfresco SDK][oop] to
 > build Docker images with your extensions.
 
-By default the `scripts/fetch-artifacts.py` script will fetch some default AMPs,
+By default the `scripts/fetch_artifacts.py` script will fetch some default AMPs,
 see the `artifacts-NN.yaml` for the version you are building for further
 details.
 
-You can replace those, remove them to keep only the ones you need or add more.
-Be careful though as some AMPs may depend on one another (e.g.
-`googldrive-repo` depends on `alfresco-share-services`).
+A context you repoint replaces this folder entirely, so your directory must also
+hold the AMPs from `artifacts-NN.yaml` you still want installed. Be careful as
+some AMPs may depend on one another (e.g. `googledrive-repo` depends on
+`alfresco-share-services`).
 
 [sdk]: https://docs.hyland.com/r/Alfresco/Alfresco-In-Process-SDK/4.10/Alfresco-In-Process-SDK/Introduction
 [oop]: https://docs.hyland.com/r/Alfresco/Alfresco-Content-Services/26.1/Alfresco-Content-Services/Develop/Out-of-Process-Extension-Points/Events-Extension-Point

--- a/repository/amps_community/README.md
+++ b/repository/amps_community/README.md
@@ -1,6 +1,9 @@
 # Alfresco Repository AMPs for Community edition
 
-Place here your Alfresco module Packages (AMPs) to be installed in the Alfresco
-repository community edition only.
+This folder is the default content of the `repo_amps_edition` build context for
+the Community edition: Alfresco Module Packages (AMPs) installed in that
+edition only.
 
+To ship AMPs of your own, repoint `repo_amps_edition` at a directory of your own
+rather than adding files here, which would require a fork of this repository.
 For more information see the main [amps README](../amps/README.md).

--- a/repository/amps_enterprise/README.md
+++ b/repository/amps_enterprise/README.md
@@ -1,6 +1,9 @@
 # Alfresco Repository AMPs for Enterprise edition
 
-Place here your Alfresco module Packages (AMPs) to be installed in the Alfresco
-repository enterprise edition only.
+This folder is the default content of the `repo_amps_edition` build context for
+the Enterprise edition: Alfresco Module Packages (AMPs) installed in that
+edition only.
 
+To ship AMPs of your own, repoint `repo_amps_edition` at a directory of your own
+rather than adding files here, which would require a fork of this repository.
 For more information see the main [amps README](../amps/README.md).

--- a/repository/distribution/README.md
+++ b/repository/distribution/README.md
@@ -1,8 +1,16 @@
 # Alfresco repository distribution
 
-Place here the version of Alfresco Content Services distribution you want to
-use in your Docker image.
-Distribution file must be a ZIP file with the expected structure of an Alfresco
+This folder is the default content of the `repo_distribution` build context: the
+Alfresco Content Services distribution the image is built from.
+`scripts/fetch_artifacts.py` populates it from the `artifacts-NN.yaml` file of
+the version you are building.
+
+To build from a distribution of your own, repoint `repo_distribution` at a
+directory of your own rather than adding files here, which would require a fork
+of this repository. See [customizing the
+image](../README.md#customizing-the-image).
+
+The distribution must be a ZIP file with the expected structure of an Alfresco
 Content Services distribution.
 
 ```tree

--- a/repository/libs/README.md
+++ b/repository/libs/README.md
@@ -1,4 +1,11 @@
 # Alfresco Content Repository extra jars
 
-Place here additional jar files you want to be deployed in Tomcat lib directory.
-This is a suitable way to add JDBC drivers, for example.
+This folder is the default content of the `repo_libs` build context: jar files
+deployed in the Tomcat lib directory, which is a suitable way to add JDBC
+drivers.
+
+To ship jars of your own, repoint `repo_libs` at a directory of your own rather
+than adding files here, which would require a fork of this repository. See
+[customizing the image](../README.md#customizing-the-image). A context you
+repoint replaces this folder entirely, so your directory must also hold the
+JDBC driver shipped here if you still need it.

--- a/repository/simple_modules/README.md
+++ b/repository/simple_modules/README.md
@@ -3,6 +3,10 @@
 You can read the full documentation about Simple Module in the [Alfresco
 documentation](https://docs.hyland.com/search/all?query=simple+module+jars&value-filters=platform_custom~%2522Alfresco%2522&content-lang=en-US).
 
-Copy jar files produced by the [Alfresco
-SDK](https://github.com/Alfresco/alfresco-sdk) into `repository/simple_modules`
-to add Simple Module to every built repository image.
+This folder is the default content of the `repo_simple_modules` build context.
+To add Simple Modules produced by the [Alfresco
+SDK](https://github.com/Alfresco/alfresco-sdk) to every built repository image,
+repoint `repo_simple_modules` at a directory of your own rather than adding
+files here, which would require a fork of this repository. See [customizing the
+image](../README.md#customizing-the-image). A context you repoint replaces this
+folder entirely.


### PR DESCRIPTION
## Intent

This is a proposal, opened for discussion rather than for merge. It prototypes on the `repository` image a way to customize Alfresco images without forking this repository, to see whether the approach is worth generalizing to the other components.

Customizing an image today means cloning this repository and changing it. That works until the next Bakery upgrade, at which point every local change is a merge to reconcile, and any edit to a Dockerfile is a likely conflict. The goal here is that consumers hold only their own files, and upgrade by changing a git ref.

Both mechanisms below are existing Docker Bake features. Nothing is invented here.

## Build inputs as named contexts

`repository` now reads its distribution, AMPs, libs and simple modules through named build contexts, each defaulting to the folder it replaces:

| Context | Default |
| --- | --- |
| `repo_distribution` | `repository/distribution` |
| `repo_amps` | `repository/amps` |
| `repo_amps_edition` | `repository/amps_<edition>` |
| `repo_libs` | `repository/libs` |
| `repo_simple_modules` | `repository/simple_modules` |

`make repository` and `docker buildx bake repository` behave exactly as before. A consumer repoints whichever inputs they need at directories of their own using `cwd://`, against a remote bake definition:

```hcl
target "repository_enterprise" {
  contexts = { repo_libs = "cwd://my-jdbc-drivers" }
  tags     = ["myregistry.domain.tld/alfresco-content-repository:26.2.1-acme1"]
}
```

```sh
docker buildx bake "https://github.com/Alfresco/alfresco-dockerfiles-bakery.git#v0.14.0" -f cwd://docker-bake.hcl repository_enterprise
```

Their bake file holds overrides only; every target, arg and label still comes from this repository. Upgrading is a matter of changing the ref.

Selecting the edition specific AMP folder moves from the Dockerfile into bake, which makes the `ALFRESCO_REPO_EDITION` build arg redundant. It is removed rather than left declared but unconsumed.

## Extending with your own layers

Anything that is not a build input, such as an OS package, an internal CA certificate or a configuration file, is added by building an image on top of the one this repository produces, referencing the target as a named context. This required no change here and is documented as it stands.

## Verified by building

Not just by reading the Bake documentation:

- `repository_enterprise` builds, and the resulting image still contains everything it did before: share-services and AOS through `repo_amps`, the enterprise only googledocs and device-sync AMPs through `repo_amps_edition`, the PostgreSQL driver through `repo_libs`, the HxInsight module through `repo_simple_modules`.
- An overlay repointing `repo_libs` at a directory outside this repository was confirmed to take effect in the built image.
- A derived image built `FROM` the repository target was confirmed to work, run as the `alfresco` user, and carry its customization.

## Two points worth deciding before this spreads

**Contexts replace, they do not merge.** A consumer overriding `repo_amps` gets only their own AMPs, silently losing `alfresco-share-services`, which Share needs. This is documented, but the alternative is an additive companion context per input (`repo_amps_custom` and friends, defaulting to an empty directory) so that consumers add without restating what this repository fetches. Worth settling before the pattern is applied to the other components.

**Derived images inherit our labels.** An image built on top of `repository` reports `org.opencontainers.image.vendor=Hyland Software, Inc.` and this repository as its source unless the consumer overrides them, so a customer image can present itself as an official build. Documented here as a note, but it may deserve something stronger.

## Scope

Only `repository` is converted. The other components still copy from their own build context; converting them follows the same pattern.

The `docs: add Claude Code and Copilot instructions` commit is unrelated to this proposal and can be split out if it gets in the way of review.
