### PR TITLE
OPSEXP-4353: Configure Tomcat from TOMCAT_* environment variables

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -102,4 +102,7 @@ jobs:
         env:
           REGISTRY: ghcr.io
           REGISTRY_NAMESPACE: alfresco
-        run: ./test/verify.sh
+          VERSION_TO_TEST: 26
+        run: |
+          export TAG=${{ github.event_name == 'pull_request' && format('pr-{0}-v{1}', github.event.pull_request.number, env.VERSION_TO_TEST) || format('{0}-v{1}', github.ref_name, env.VERSION_TO_TEST) }}
+          ./test/verify.sh

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -94,8 +94,9 @@ jobs:
       - name: Setup hcl2json
         uses: Alfresco/alfresco-build-tools/.github/actions/setup-github-release-binary@v18.21.2
         with:
-          repo: 'tmccombs/hcl2json'
-          version: 'v0.6.9'
+          repo: tmccombs/hcl2json
+          version: 0.6.9
+          url_template: v${VERSION}/${NAME}_${OS}_${ARCH}.tar.gz
 
       - name: Run image verification tests
         env:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -91,6 +91,13 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Setup hcl2json
+        uses: Alfresco/alfresco-build-tools/.github/actions/setup-github-release-binary@v18.21.2
+        with:
+          github-release-binary-org: 'tmccombs'
+          github-release-binary-repo: 'hcl2json'
+          github-release-binary-name: 'hcl2json'
+
       - name: Run image verification tests
         env:
           REGISTRY: ghcr.io

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -91,13 +91,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Setup hcl2json
-        uses: Alfresco/alfresco-build-tools/.github/actions/setup-github-release-binary@v18.21.2
-        with:
-          repo: tmccombs/hcl2json
-          version: 0.6.9
-          url_template: v${VERSION}/${NAME}_${OS}_${ARCH}.tar.gz
-
       - name: Run image verification tests
         env:
           REGISTRY: ghcr.io

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -68,12 +68,16 @@ jobs:
     secrets: inherit
 
   image-tests:
-    name: Run image verification tests
+    name: Test images v${{ matrix.version }}
     needs: [ACS_CI, APS_CI]
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: read
+    strategy:
+      fail-fast: false
+      matrix:
+        version: [26, 25]
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -95,7 +99,6 @@ jobs:
         env:
           REGISTRY: ghcr.io
           REGISTRY_NAMESPACE: alfresco
-          VERSION_TO_TEST: 26
-        run: |
-          export TAG=${{ github.event_name == 'pull_request' && format('pr-{0}-v{1}', github.event.pull_request.number, env.VERSION_TO_TEST) || format('{0}-v{1}', github.ref_name, env.VERSION_TO_TEST) }}
-          ./test/verify.sh
+          ACS_VERSION: ${{ matrix.version }}
+          TAG: ${{ github.event_name == 'pull_request' && format('pr-{0}-v{1}', github.event.pull_request.number, matrix.version) || format('{0}-v{1}', github.ref_name, matrix.version) }}
+        run: ./test/verify.sh

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -66,3 +66,33 @@ jobs:
       tag: ${{ github.event_name == 'pull_request' && format('pr-{0}-v{1}', github.event.pull_request.number, matrix.version) || format('{0}-v{1}', github.ref_name, matrix.version) }}
       aps_version: ${{ matrix.version }}
     secrets: inherit
+
+  image-tests:
+    name: Run image verification tests
+    needs: [ACS_CI, APS_CI]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4.6.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run image verification tests
+        env:
+          REGISTRY: ghcr.io
+          REGISTRY_NAMESPACE: alfresco
+        run: ./test/verify.sh

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -94,9 +94,8 @@ jobs:
       - name: Setup hcl2json
         uses: Alfresco/alfresco-build-tools/.github/actions/setup-github-release-binary@v18.21.2
         with:
-          github-release-binary-org: 'tmccombs'
-          github-release-binary-repo: 'hcl2json'
-          github-release-binary-name: 'hcl2json'
+          repo: 'tmccombs/hcl2json'
+          version: 'v0.6.9'
 
       - name: Run image verification tests
         env:

--- a/README.md
+++ b/README.md
@@ -153,6 +153,10 @@ make all
 
 ## Customizing the images
 
+All the images running a Java web application are built on the Alfresco base
+Tomcat image. The servlet container they embed is configured with the `TOMCAT_*`
+environment variables documented in [tomcat/README.md](tomcat/README.md).
+
 ### Customizing the Alfresco Content Repository image
 
 The Alfresco Content Repository image can be customized by adding files into

--- a/TESTING.md
+++ b/TESTING.md
@@ -10,7 +10,7 @@ This project uses a lightweight test discovery and execution system for verifyin
 - Each test script receives the image name as its first argument
 
 **Automatic discovery:**
-- `./verify.sh` discovers all test files and runs them
+- `./test/verify.sh` discovers all test files and runs them
 - For each test, it determines which bake target provides that image
 - If the target is cache-only (like `tomcat_base`), it finds the first final target that inherits from it
 - Tests run against real, runnable images (not intermediate/cache-only ones)
@@ -27,7 +27,7 @@ docker run --rm "$IMAGE" catalina.sh configtest 2>&1 | grep -q "Loaded Apache To
 
 ```bash
 # Run all discovered tests
-./verify.sh
+./test/verify.sh
 
 # Tests will:
 # 1. Discover all */tests/*_test.sh files
@@ -57,7 +57,7 @@ docker run --rm "$IMAGE" catalina.sh configtest 2>&1 | grep -q "Loaded Apache To
    chmod +x myimage/tests/my_feature_test.sh
    ```
 
-4. Run `./verify.sh` to test it
+4. Run `./test/verify.sh` to test it
 
 ## Test requirements
 
@@ -72,7 +72,7 @@ Add to your GitHub Actions workflow:
 
 ```yaml
 - name: Run image tests
-  run: ./verify.sh
+  run: ./test/verify.sh
 ```
 
 Tests will automatically fail the workflow if any test fails.

--- a/TESTING.md
+++ b/TESTING.md
@@ -14,6 +14,9 @@ This project uses a lightweight test discovery and execution system for verifyin
 - For each test, it determines which bake target provides that image
 - If the target is cache-only (like `tomcat_base`), it finds the first final target that inherits from it
 - Tests run against real, runnable images (not intermediate/cache-only ones)
+- Image references come from `docker buildx bake --print`, so matrix targets,
+  `image_tag()` and the `REGISTRY`/`REGISTRY_NAMESPACE`/`TAG` variables resolve
+  exactly as they do at build time
 
 **Example test:**
 ```bash
@@ -32,7 +35,7 @@ docker run --rm "$IMAGE" catalina.sh configtest 2>&1 | grep -q "Loaded Apache To
 # Tests will:
 # 1. Discover all */tests/*_test.sh files
 # 2. Map each to its bake target
-# 3. Find an appropriate runnable image
+# 3. Resolve that target's tag through bake
 # 4. Execute the test
 # 5. Report results
 ```
@@ -62,7 +65,7 @@ docker run --rm "$IMAGE" catalina.sh configtest 2>&1 | grep -q "Loaded Apache To
 ## Test requirements
 
 - Tests must exit with `0` on success, non-zero on failure
-- Tests receive the image name (`image:latest`) as the first argument
+- Tests receive the fully resolved image reference (`registry/namespace/image:version`) as the first argument
 - Tests should be isolated and not depend on external state
 - Keep tests fast—they run after every build
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,78 @@
+# Image Testing
+
+This project uses a lightweight test discovery and execution system for verifying Docker images.
+
+## How it works
+
+**Test structure:**
+- Tests live in `<image>/tests/` directories
+- Test files are named `*_test.sh` (e.g., `tomcat_native_test.sh`)
+- Each test script receives the image name as its first argument
+
+**Automatic discovery:**
+- `./verify.sh` discovers all test files and runs them
+- For each test, it determines which bake target provides that image
+- If the target is cache-only (like `tomcat_base`), it finds the first final target that inherits from it
+- Tests run against real, runnable images (not intermediate/cache-only ones)
+
+**Example test:**
+```bash
+#!/bin/bash
+# tomcat/tests/tomcat_native_test.sh
+IMAGE=$1
+docker run --rm "$IMAGE" catalina.sh configtest 2>&1 | grep -q "Loaded Apache Tomcat Native library"
+```
+
+## Running tests
+
+```bash
+# Run all discovered tests
+./verify.sh
+
+# Tests will:
+# 1. Discover all */tests/*_test.sh files
+# 2. Map each to its bake target
+# 3. Find an appropriate runnable image
+# 4. Execute the test
+# 5. Report results
+```
+
+## Adding tests
+
+1. Create a `tests/` directory in your image folder if it doesn't exist:
+   ```bash
+   mkdir -p myimage/tests
+   ```
+
+2. Write a test script (must be executable):
+   ```bash
+   # myimage/tests/my_feature_test.sh
+   #!/bin/bash
+   IMAGE=$1
+   docker run --rm "$IMAGE" /verify-my-feature.sh
+   ```
+
+3. Make it executable:
+   ```bash
+   chmod +x myimage/tests/my_feature_test.sh
+   ```
+
+4. Run `./verify.sh` to test it
+
+## Test requirements
+
+- Tests must exit with `0` on success, non-zero on failure
+- Tests receive the image name (`image:latest`) as the first argument
+- Tests should be isolated and not depend on external state
+- Keep tests fast—they run after every build
+
+## Integration with CI
+
+Add to your GitHub Actions workflow:
+
+```yaml
+- name: Run image tests
+  run: ./verify.sh
+```
+
+Tests will automatically fail the workflow if any test fails.

--- a/aps/admin/README.md
+++ b/aps/admin/README.md
@@ -38,6 +38,12 @@ alfresco-activiti-admin:
 |-------------|---------|-----------------------------------------------------|
 | `JAVA_OPTS` |    None | can be used to pass additional JRE options          |
 
+### Tomcat configuration
+
+This image is built on the Alfresco base Tomcat image, so the servlet container
+itself is configured with the `TOMCAT_*` environment variables documented in
+[tomcat/README.md](../../tomcat/README.md).
+
 ### Database configuration
 
 | Variable                             | Default                                      | Description                          |

--- a/aps/app/README.md
+++ b/aps/app/README.md
@@ -60,6 +60,12 @@ alfresco-activiti:
 |-------------|---------|-----------------------------------------------------|
 | `JAVA_OPTS` |    None | can be used to pass additional JRE options          |
 
+### Tomcat configuration
+
+This image is built on the Alfresco base Tomcat image, so the servlet container
+itself is configured with the `TOMCAT_*` environment variables documented in
+[tomcat/README.md](../../tomcat/README.md).
+
 ### Database configuration
 | Variable                             | Default                                      | Description                          |
 |--------------------------------------|----------------------------------------------|--------------------------------------|

--- a/repository/README.md
+++ b/repository/README.md
@@ -36,3 +36,9 @@ docker run -e JAVA_OPTS="-Ddb.url=jdbc:postgresql://postgres.domain.tld:5432/alf
 > If the image is meant to be used with the Alfresco Content Services Helm
 > chart, you can use other [higher level means of
 > configuration](https://github.com/Alfresco/alfresco-helm-charts/blob/main/charts/alfresco-repository/docs/repository-properties.md).
+
+### Tomcat configuration
+
+This image is built on the Alfresco base Tomcat image, so the servlet container
+itself is configured with the `TOMCAT_*` environment variables documented in
+[tomcat/README.md](../tomcat/README.md).

--- a/share/README.md
+++ b/share/README.md
@@ -60,3 +60,9 @@ alfresco-connector-ms365:
 > If the image is meant to be used with the Alfresco Content Services Helm
 > chart, you can use other [higher level means of
 > configuration](https://github.com/Alfresco/alfresco-helm-charts/blob/main/charts/alfresco-share/README.md).
+
+### Tomcat configuration
+
+This image is built on the Alfresco base Tomcat image, so the servlet container
+itself is configured with the `TOMCAT_*` environment variables documented in
+[tomcat/README.md](../tomcat/README.md).

--- a/test/verify.sh
+++ b/test/verify.sh
@@ -1,0 +1,199 @@
+#!/bin/bash
+# verify.sh - Auto-discover and run image tests
+# Finds */tests/*_test.sh files and runs them against appropriate images
+# based on docker-bake.hcl inheritance relationships
+
+set -e
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HCL_FILE="$REPO_ROOT/docker-bake.hcl"
+
+REGISTRY="${REGISTRY:-localhost}"
+REGISTRY_NAMESPACE="${REGISTRY_NAMESPACE:-alfresco}"
+
+# Initialize artifact versions for tag resolution
+export ARTIFACT_VERSIONS=$(python3 "$REPO_ROOT/scripts/print_artifact_versions.py")
+
+# ============================================================================
+# Helper: Find the bake target that uses a given folder as its main context
+# ============================================================================
+find_target_for_context() {
+  local context="$1"
+  hcl2json "$HCL_FILE" 2>/dev/null | jq -r "
+    .target | to_entries[] |
+    select(.value[0].context == \"$context\") |
+    .key
+  "
+}
+
+# ============================================================================
+# Helper: Get the first final target that inherits from a given target
+# ============================================================================
+find_final_target_inheriting_from() {
+  local parent_target="$1"
+  hcl2json "$HCL_FILE" 2>/dev/null | jq -r "
+    ([
+      .target | to_entries[] |
+      select(
+        (.value[0].inherits | index(\"$parent_target\")) or
+        (.value[0].contexts | has(\"$parent_target\"))
+      ) |
+      select(
+        (.value[0].output[0] // \"type=docker\") | contains(\"cacheonly\") | not
+      ) |
+      .key
+    ] | first) // empty
+  "
+}
+
+# ============================================================================
+# Helper: Check if a target is final (not cache-only)
+# ============================================================================
+is_target_final() {
+  local target="$1"
+  hcl2json "$HCL_FILE" 2>/dev/null | jq -e "
+    .target[\"$target\"][0].output[0] // \"type=docker\" | contains(\"cacheonly\") | not
+  " >/dev/null 2>&1
+}
+
+# ============================================================================
+# Helper: Get the full tag for a target (with registry, namespace, and version)
+# ============================================================================
+get_image_tag_for_target() {
+  local target="$1"
+  local image_name version
+
+  # Extract image name from bake target tag template
+  image_name=$(hcl2json "$HCL_FILE" 2>/dev/null | jq -r "
+    .target[\"$target\"][0].tags[0] | split(\"/\")[-1] | split(\":\")[0]
+  ")
+
+  # Look up version from artifact versions
+  version=$(echo "$ARTIFACT_VERSIONS" | jq -r ".\"$image_name\" // \"latest\"")
+
+  # Construct full tag: registry/namespace/image:version
+  echo "$REGISTRY/$REGISTRY_NAMESPACE/$image_name:$version"
+}
+
+# ============================================================================
+# Validation
+# ============================================================================
+if [ ! -f "$HCL_FILE" ]; then
+  echo "Error: $HCL_FILE not found" >&2
+  exit 1
+fi
+
+if ! command -v hcl2json &>/dev/null; then
+  echo "Error: hcl2json not found. Install it to continue." >&2
+  exit 1
+fi
+
+# ============================================================================
+# Main: Discover and run tests
+# ============================================================================
+run_test() {
+  local test_file="$1"
+  local test_dir="$(dirname "$test_file")"
+  local dockerfile_dir="${test_dir%/tests}"
+  dockerfile_dir="${dockerfile_dir#./}"
+  local context="./$dockerfile_dir"
+  local test_name="$(basename "$test_file")"
+
+  echo "  📋 Test: $test_name"
+  echo "     Path: $test_file"
+
+  # Find the bake target that uses this folder as context
+  local bake_target=$(find_target_for_context "$context")
+
+  if [ -z "$bake_target" ]; then
+    echo "     ⏭️  Skipped: No bake target found for context $context"
+    echo ""
+    return 2  # Skip (neither pass nor fail)
+  fi
+
+  echo "     🎯 Target: $bake_target"
+
+  # Determine which image to test against
+  local target_to_run="$bake_target"
+  if is_target_final "$bake_target"; then
+    echo "     🐳 Target is final"
+  else
+    # Target is not final (e.g., cache-only), find a final target that inherits from it
+    target_to_run=$(find_final_target_inheriting_from "$bake_target")
+    if [ -n "$target_to_run" ]; then
+      echo "     🐳 Target to test: $target_to_run (inherited from $bake_target)"
+    fi
+  fi
+
+  if [ -z "$target_to_run" ]; then
+    echo "     ❌ Failed: Could not determine target to run for $bake_target"
+    echo ""
+    return 1
+  fi
+
+  # Get full image tag (with registry, namespace, and version)
+  local full_image_tag=$(get_image_tag_for_target "$target_to_run")
+
+  # Run the test
+  echo "     ▶️  Running test..."
+  if bash "$test_file" "$full_image_tag"; then
+    echo "     ✅ Passed"
+    echo ""
+    return 0
+  else
+    echo "     ❌ Failed"
+    echo ""
+    return 1
+  fi
+}
+
+main() {
+  test_count=0
+  passed_count=0
+  failed_count=0
+
+  echo ""
+  echo "🧪 Image Test Verification"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo ""
+
+  # Group tests by folder
+  local current_folder=""
+  while IFS= read -r test_file; do
+    local test_dir="$(dirname "$test_file")"
+    local dockerfile_dir="${test_dir%/tests}"
+    dockerfile_dir="${dockerfile_dir#./}"
+
+    # Print folder header when folder changes
+    if [ "$dockerfile_dir" != "$current_folder" ]; then
+      if [ -n "$current_folder" ]; then
+        echo ""
+      fi
+      echo "📁 $dockerfile_dir/"
+      current_folder="$dockerfile_dir"
+    fi
+
+    test_count=$((test_count + 1))
+    run_test "$test_file"
+    result=$?
+
+    if [ $result -eq 0 ]; then
+      passed_count=$((passed_count + 1))
+    elif [ $result -eq 1 ]; then
+      failed_count=$((failed_count + 1))
+    fi
+  done < <(cd "$REPO_ROOT" && find . -path "*/tests/*_test.sh" -type f | sort)
+
+  # Summary
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  if [ $failed_count -eq 0 ]; then
+    echo "✨ All tests passed! ($passed_count/$test_count)"
+    echo ""
+  else
+    echo "⚠️  Results: $passed_count passed, $failed_count failed out of $test_count tests"
+    echo ""
+    exit 1
+  fi
+}
+
+main "$@"

--- a/test/verify.sh
+++ b/test/verify.sh
@@ -31,9 +31,12 @@ find_target_for_context() {
 # ============================================================================
 find_final_target_inheriting_from() {
   local parent_target="$1"
+  hcl2json "$HCL_FILE" 2>/dev/null | jq -r "
+    ([
+      .target | to_entries[] |
       select(
-        ((.value[0].inherits // []) | index("$parent_target")) or
-        ((.value[0].contexts // {}) | has("$parent_target"))
+        ((.value[0].inherits // []) | index(\"$parent_target\")) or
+        ((.value[0].contexts // {}) | has(\"$parent_target\"))
       ) |
       select(
         (.value[0].output[0] // \"type=docker\") | contains(\"cacheonly\") | not

--- a/test/verify.sh
+++ b/test/verify.sh
@@ -72,7 +72,7 @@ get_image_tag_for_target() {
   version=$(echo "$ARTIFACT_VERSIONS" | jq -r ".\"$image_name\" // \"latest\"")
 
   # Construct full tag: registry/namespace/image:version
-  echo "$REGISTRY/$REGISTRY_NAMESPACE/$image_name:$version"
+  echo "$REGISTRY/$REGISTRY_NAMESPACE/$image_name:${TAG:-$version}"
 }
 
 # ============================================================================

--- a/test/verify.sh
+++ b/test/verify.sh
@@ -31,12 +31,9 @@ find_target_for_context() {
 # ============================================================================
 find_final_target_inheriting_from() {
   local parent_target="$1"
-  hcl2json "$HCL_FILE" 2>/dev/null | jq -r "
-    ([
-      .target | to_entries[] |
       select(
-        (.value[0].inherits | index(\"$parent_target\")) or
-        (.value[0].contexts | has(\"$parent_target\"))
+        ((.value[0].inherits // []) | index("$parent_target")) or
+        ((.value[0].contexts // {}) | has("$parent_target"))
       ) |
       select(
         (.value[0].output[0] // \"type=docker\") | contains(\"cacheonly\") | not
@@ -186,11 +183,13 @@ main() {
 
   # Summary
   echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  executed_count=$((passed_count + failed_count))
+  skipped_count=$((test_count - executed_count))
   if [ $failed_count -eq 0 ]; then
-    echo "✨ All tests passed! ($passed_count/$test_count)"
+    echo "✨ All executed tests passed! ($passed_count/$executed_count; skipped $skipped_count)"
     echo ""
   else
-    echo "⚠️  Results: $passed_count passed, $failed_count failed out of $test_count tests"
+    echo "⚠️  Results: $passed_count passed, $failed_count failed out of $executed_count executed tests (skipped $skipped_count)"
     echo ""
     exit 1
   fi

--- a/test/verify.sh
+++ b/test/verify.sh
@@ -145,7 +145,7 @@ run_test() {
 }
 
 main() {
-  local test_count=0 passed_count=0 failed_count=0 current_folder="" result
+  local test_count=0 passed_count=0 failed_count=0 skipped_count=0 current_folder="" result
 
   echo ""
   echo "🧪 Image Test Verification"
@@ -172,15 +172,20 @@ main() {
       passed_count=$((passed_count + 1))
     elif [ "$result" -eq 1 ]; then
       failed_count=$((failed_count + 1))
+    else
+      skipped_count=$((skipped_count + 1))
     fi
   done < <(cd "$REPO_ROOT" && find . -path "*/tests/*_test.sh" -type f | sort)
 
+  local skipped_note=""
+  [ "$skipped_count" -gt 0 ] && skipped_note=", $skipped_count skipped"
+
   echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
   if [ "$failed_count" -eq 0 ]; then
-    echo "✨ All tests passed! ($passed_count/$test_count)"
+    echo "✨ All tests passed! ($passed_count/$test_count$skipped_note)"
     echo ""
   else
-    echo "⚠️  Results: $passed_count passed, $failed_count failed out of $test_count tests"
+    echo "⚠️  Results: $passed_count passed, $failed_count failed$skipped_note out of $test_count tests"
     echo ""
     exit 1
   fi

--- a/test/verify.sh
+++ b/test/verify.sh
@@ -6,24 +6,23 @@
 set -e
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-HCL_FILE="$REPO_ROOT/docker-bake.hcl"
 
-REGISTRY="${REGISTRY:-localhost}"
-REGISTRY_NAMESPACE="${REGISTRY_NAMESPACE:-alfresco}"
+# Groups whose target graph is searched for images to test
+BAKE_GROUPS="${BAKE_GROUPS:-default aps}"
 
-# Initialize artifact versions for tag resolution
-export ARTIFACT_VERSIONS=$(python3 "$REPO_ROOT/scripts/print_artifact_versions.py")
+BAKE_JSON="$(mktemp)"
+trap 'rm -f "$BAKE_JSON"' EXIT
 
 # ============================================================================
 # Helper: Find the bake target that uses a given folder as its main context
 # ============================================================================
 find_target_for_context() {
   local context="$1"
-  hcl2json "$HCL_FILE" 2>/dev/null | jq -r "
+  jq -r --arg context "$context" '
     .target | to_entries[] |
-    select(.value[0].context == \"$context\") |
+    select(.value.context == $context) |
     .key
-  "
+  ' "$BAKE_JSON"
 }
 
 # ============================================================================
@@ -31,19 +30,15 @@ find_target_for_context() {
 # ============================================================================
 find_final_target_inheriting_from() {
   local parent_target="$1"
-  hcl2json "$HCL_FILE" 2>/dev/null | jq -r "
+  jq -r --arg parent "$parent_target" '
+    def is_final: [(.value.output // [])[].type] | index("cacheonly") | not;
     ([
       .target | to_entries[] |
-      select(
-        ((.value[0].inherits // []) | index(\"$parent_target\")) or
-        ((.value[0].contexts // {}) | has(\"$parent_target\"))
-      ) |
-      select(
-        (.value[0].output[0] // \"type=docker\") | contains(\"cacheonly\") | not
-      ) |
+      select((.value.contexts // {}) | has($parent)) |
+      select(is_final) |
       .key
     ] | first) // empty
-  "
+  ' "$BAKE_JSON"
 }
 
 # ============================================================================
@@ -51,64 +46,60 @@ find_final_target_inheriting_from() {
 # ============================================================================
 is_target_final() {
   local target="$1"
-  hcl2json "$HCL_FILE" 2>/dev/null | jq -e "
-    .target[\"$target\"][0].output[0] // \"type=docker\" | contains(\"cacheonly\") | not
-  " >/dev/null 2>&1
+  jq -e --arg target "$target" '
+    [(.target[$target].output // [])[].type] | index("cacheonly") | not
+  ' "$BAKE_JSON" >/dev/null 2>&1
 }
 
 # ============================================================================
-# Helper: Get the full tag for a target (with registry, namespace, and version)
+# Helper: Get the fully resolved tag bake would build the target with
 # ============================================================================
 get_image_tag_for_target() {
   local target="$1"
-  local image_name version
-
-  # Extract image name from bake target tag template
-  image_name=$(hcl2json "$HCL_FILE" 2>/dev/null | jq -r "
-    .target[\"$target\"][0].tags[0] | split(\"/\")[-1] | split(\":\")[0]
-  ")
-
-  # Look up version from artifact versions
-  version=$(echo "$ARTIFACT_VERSIONS" | jq -r ".\"$image_name\" // \"latest\"")
-
-  # Construct full tag: registry/namespace/image:version
-  echo "$REGISTRY/$REGISTRY_NAMESPACE/$image_name:${TAG:-$version}"
+  jq -r --arg target "$target" '.target[$target].tags[0] // empty' "$BAKE_JSON"
 }
 
 # ============================================================================
 # Validation
 # ============================================================================
-if [ ! -f "$HCL_FILE" ]; then
-  echo "Error: $HCL_FILE not found" >&2
+if ! docker buildx version &>/dev/null; then
+  echo "Error: docker buildx not found. Install it to continue." >&2
   exit 1
 fi
 
-if ! command -v hcl2json &>/dev/null; then
-  echo "Error: hcl2json not found. Install it to continue." >&2
+# Resolve the bake graph once: expands matrices, image_tag() and the
+# registry/namespace variables the way a build would
+# shellcheck disable=SC2086
+ARTIFACT_VERSIONS="$(python3 "$REPO_ROOT/scripts/print_artifact_versions.py")" \
+  docker buildx bake --file "$REPO_ROOT/docker-bake.hcl" --print $BAKE_GROUPS \
+  >"$BAKE_JSON" 2>/dev/null || {
+  echo "Error: failed to resolve bake targets for groups: $BAKE_GROUPS" >&2
   exit 1
-fi
+}
 
 # ============================================================================
 # Main: Discover and run tests
 # ============================================================================
 run_test() {
   local test_file="$1"
-  local test_dir="$(dirname "$test_file")"
-  local dockerfile_dir="${test_dir%/tests}"
+  local test_dir dockerfile_dir context test_name
+  test_dir="$(dirname "$test_file")"
+  dockerfile_dir="${test_dir%/tests}"
   dockerfile_dir="${dockerfile_dir#./}"
-  local context="./$dockerfile_dir"
-  local test_name="$(basename "$test_file")"
+  context="$dockerfile_dir"
+  test_name="$(basename "$test_file")"
 
   echo "  📋 Test: $test_name"
   echo "     Path: $test_file"
 
   # Find the bake target that uses this folder as context
-  local bake_target=$(find_target_for_context "$context")
+  local bake_target
+  bake_target=$(find_target_for_context "$context")
 
   if [ -z "$bake_target" ]; then
     echo "     ⏭️  Skipped: No bake target found for context $context"
     echo ""
-    return 2  # Skip (neither pass nor fail)
+    return 2
   fi
 
   echo "     🎯 Target: $bake_target"
@@ -131,10 +122,16 @@ run_test() {
     return 1
   fi
 
-  # Get full image tag (with registry, namespace, and version)
-  local full_image_tag=$(get_image_tag_for_target "$target_to_run")
+  local full_image_tag
+  full_image_tag=$(get_image_tag_for_target "$target_to_run")
 
-  # Run the test
+  if [ -z "$full_image_tag" ]; then
+    echo "     ❌ Failed: Target $target_to_run has no tag"
+    echo ""
+    return 1
+  fi
+
+  echo "     🏷️  Image: $full_image_tag"
   echo "     ▶️  Running test..."
   if bash "$test_file" "$full_image_tag"; then
     echo "     ✅ Passed"
@@ -148,51 +145,42 @@ run_test() {
 }
 
 main() {
-  test_count=0
-  passed_count=0
-  failed_count=0
+  local test_count=0 passed_count=0 failed_count=0 current_folder="" result
 
   echo ""
   echo "🧪 Image Test Verification"
   echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
   echo ""
 
-  # Group tests by folder
-  local current_folder=""
   while IFS= read -r test_file; do
-    local test_dir="$(dirname "$test_file")"
-    local dockerfile_dir="${test_dir%/tests}"
+    local test_dir dockerfile_dir
+    test_dir="$(dirname "$test_file")"
+    dockerfile_dir="${test_dir%/tests}"
     dockerfile_dir="${dockerfile_dir#./}"
 
-    # Print folder header when folder changes
     if [ "$dockerfile_dir" != "$current_folder" ]; then
-      if [ -n "$current_folder" ]; then
-        echo ""
-      fi
+      [ -n "$current_folder" ] && echo ""
       echo "📁 $dockerfile_dir/"
       current_folder="$dockerfile_dir"
     fi
 
     test_count=$((test_count + 1))
-    run_test "$test_file"
-    result=$?
+    result=0
+    run_test "$test_file" || result=$?
 
-    if [ $result -eq 0 ]; then
+    if [ "$result" -eq 0 ]; then
       passed_count=$((passed_count + 1))
-    elif [ $result -eq 1 ]; then
+    elif [ "$result" -eq 1 ]; then
       failed_count=$((failed_count + 1))
     fi
   done < <(cd "$REPO_ROOT" && find . -path "*/tests/*_test.sh" -type f | sort)
 
-  # Summary
   echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-  executed_count=$((passed_count + failed_count))
-  skipped_count=$((test_count - executed_count))
-  if [ $failed_count -eq 0 ]; then
-    echo "✨ All executed tests passed! ($passed_count/$executed_count; skipped $skipped_count)"
+  if [ "$failed_count" -eq 0 ]; then
+    echo "✨ All tests passed! ($passed_count/$test_count)"
     echo ""
   else
-    echo "⚠️  Results: $passed_count passed, $failed_count failed out of $executed_count executed tests (skipped $skipped_count)"
+    echo "⚠️  Results: $passed_count passed, $failed_count failed out of $test_count tests"
     echo ""
     exit 1
   fi

--- a/tomcat/Dockerfile
+++ b/tomcat/Dockerfile
@@ -151,13 +151,6 @@ SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 RUN mkdir -m 770 logs temp work && chgrp tomcat . logs temp work; \
   find . -type d -exec chmod ug+rx {} +; \
   chmod ug+rx bin/*.sh; \
-  # verify Tomcat Native is working properly
-  nativeLines="$(catalina.sh configtest 2>&1 | grep -c 'Loaded Apache Tomcat Native library')" && \
-  test $nativeLines -ge 1 || { echo "Tomcat Native library not found or not working properly"; exit 1; }
-# Verify placeholders resolve: a value holding a closing brace truncates silently
-RUN out="$(TOMCAT_HTTP_PORT=9999 catalina.sh configtest 2>&1 || true)"; \
-  grep -q 'http-nio-9999' <<<"$out" || { echo "$out"; echo "TOMCAT_* env vars are not applied to server.xml"; exit 1; }; \
-  ! grep -qE '\$\{|Exception' <<<"$out" || { echo "$out"; echo "Unresolved placeholder or invalid value in server.xml"; exit 1; }; \
   rm -f logs/*
 USER tomcat
 EXPOSE 8080

--- a/tomcat/Dockerfile
+++ b/tomcat/Dockerfile
@@ -1,4 +1,4 @@
-# hadolint global ignore=DL3033,DL3008,SC2016
+# hadolint global ignore=DL3033,DL3008
 # Alfresco Base Tomcat Image
 # see also https://github.com/docker-library/tomcat
 ARG JAVA_MAJOR
@@ -48,7 +48,9 @@ WORKDIR /build/tomcat/lib/org/apache/catalina/util
 RUN printf "server.info=Alfresco servlet container/$TOMCAT_MAJOR\nserver.number=$TOMCAT_MAJOR" > ServerInfo.properties
 WORKDIR /build/tomcat
 # Enable environment variable substitution in Tomcat XML configs
+# hadolint ignore=SC2016
 RUN echo 'org.apache.tomcat.util.digester.PROPERTY_SOURCE=org.apache.tomcat.util.digester.EnvironmentPropertySource' >> conf/catalina.properties
+# hadolint ignore=SC2016
 RUN connector='/Server/Service[@name="Catalina"]/Connector[@protocol="HTTP/1.1"]'; \
   host='/Server/Service[@name="Catalina"]/Engine[@name="Catalina"]/Host[@name="localhost"]'; \
   version_logger='/Server/Listener[@className="org.apache.catalina.startup.VersionLoggerListener"]'; \

--- a/tomcat/Dockerfile
+++ b/tomcat/Dockerfile
@@ -146,6 +146,11 @@ RUN mkdir -m 770 logs temp work && chgrp tomcat . logs temp work; \
   # verify Tomcat Native is working properly
   nativeLines="$(catalina.sh configtest 2>&1 | grep -c 'Loaded Apache Tomcat Native library')" && \
   test $nativeLines -ge 1 || { echo "Tomcat Native library not found or not working properly"; exit 1; }
+# Verify placeholders resolve: a value holding a closing brace truncates silently
+RUN out="$(TOMCAT_HTTP_PORT=9999 catalina.sh configtest 2>&1 || true)"; \
+  grep -q 'http-nio-9999' <<<"$out" || { echo "$out"; echo "TOMCAT_* env vars are not applied to server.xml"; exit 1; }; \
+  ! grep -qE '\$\{|Exception' <<<"$out" || { echo "$out"; echo "Unresolved placeholder or invalid value in server.xml"; exit 1; }; \
+  rm -f logs/*
 USER tomcat
 EXPOSE 8080
 # Starting tomcat with Security Manager

--- a/tomcat/Dockerfile
+++ b/tomcat/Dockerfile
@@ -1,4 +1,4 @@
-# hadolint global ignore=DL3033,DL3008
+# hadolint global ignore=DL3033,DL3008,SC2016
 # Alfresco Base Tomcat Image
 # see also https://github.com/docker-library/tomcat
 ARG JAVA_MAJOR
@@ -47,30 +47,48 @@ RUN find ./bin/ -name '*.sh' -exec sed -ri 's|^#!/bin/sh$|#!/usr/bin/env bash|' 
 WORKDIR /build/tomcat/lib/org/apache/catalina/util
 RUN printf "server.info=Alfresco servlet container/$TOMCAT_MAJOR\nserver.number=$TOMCAT_MAJOR" > ServerInfo.properties
 WORKDIR /build/tomcat
-RUN xmlstarlet ed -L \
+# Enable environment variable substitution in Tomcat XML configs
+RUN echo 'org.apache.tomcat.util.digester.PROPERTY_SOURCE=org.apache.tomcat.util.digester.EnvironmentPropertySource' >> conf/catalina.properties
+RUN connector='/Server/Service[@name="Catalina"]/Connector[@protocol="HTTP/1.1"]'; \
+  host='/Server/Service[@name="Catalina"]/Engine[@name="Catalina"]/Host[@name="localhost"]'; \
+  version_logger='/Server/Listener[@className="org.apache.catalina.startup.VersionLoggerListener"]'; \
+  xmlstarlet ed -L \
   # Remove comments
   -d '//comment()' \
   # Disable shutdown port
-  -d '/Server/@shutdown' -u '/Server/@port' -v -1 \
+  -d '/Server/@shutdown' -u '/Server/@port' -v '${TOMCAT_SHUTDOWN_PORT:--1}' \
   # Remove server banner
-  -u '/Server/Service[@name="Catalina"]/Connector[@port=8080]/@Server' -v "" \
-  # Disable auto deployment of webapps
-  -a '/Server/Service[@name="Catalina"]/Engine[@name="Catalina"]/Host[@name="localhost"]' -t attr -n deployXML -v false \
-  -u '/Server/Service[@name="Catalina"]/Engine[@name="Catalina"]/Host[@name="localhost"]/@autoDeploy' -v false \
-  -u '/Server/Service[@name="Catalina"]/Engine[@name="Catalina"]/Host[@name="localhost"]/@unpackWARs' -v false \
+  -u "$connector/@Server" -v "" \
+  # HTTP connector sizing and timeouts
+  -u "$connector/@port" -v '${TOMCAT_HTTP_PORT:-8080}' \
+  -u "$connector/@connectionTimeout" -v '${TOMCAT_HTTP_CONNECTION_TIMEOUT:-20000}' \
+  -a "$connector" -t attr -n maxThreads -v '${TOMCAT_HTTP_MAX_THREADS:-200}' \
+  -a "$connector" -t attr -n minSpareThreads -v '${TOMCAT_HTTP_MIN_SPARE_THREADS:-10}' \
+  -a "$connector" -t attr -n acceptCount -v '${TOMCAT_HTTP_ACCEPT_COUNT:-100}' \
+  -a "$connector" -t attr -n maxConnections -v '${TOMCAT_HTTP_MAX_CONNECTIONS:-8192}' \
+  -a "$connector" -t attr -n maxHttpHeaderSize -v '${TOMCAT_HTTP_MAX_HTTP_HEADER_SIZE:-8192}' \
+  -a "$connector" -t attr -n maxPostSize -v '${TOMCAT_HTTP_MAX_POST_SIZE:-2097152}' \
+  # Disable auto deployment of webapps (overridable via env vars at runtime)
+  -a "$host" -t attr -n deployXML -v '${TOMCAT_DEPLOY_XML:-false}' \
+  -u "$host/@autoDeploy" -v '${TOMCAT_AUTO_DEPLOY:-false}' \
+  -u "$host/@unpackWARs" -v '${TOMCAT_UNPACK_WARS:-false}' \
   # Enable RemoteIP valve for better handling when behind reverse proxy
-  -s '/Server/Service[@name="Catalina"]/Engine[@name="Catalina"]/Host[@name="localhost"]' -t elem -n 'Valve' \
-  -a '/Server/Service[@name="Catalina"]/Engine[@name="Catalina"]/Host[@name="localhost"]/Valve[last()]' -t attr -n className -v org.apache.catalina.valves.RemoteIpValve \
-  -a '/Server/Service[@name="Catalina"]/Engine[@name="Catalina"]/Host[@name="localhost"]/Valve[last()]' -t attr -n portHeader -v X-Forwarded-Port \
+  -s "$host" -t elem -n 'Valve' \
+  -a "$host/Valve[last()]" -t attr -n className -v org.apache.catalina.valves.RemoteIpValve \
+  -a "$host/Valve[last()]" -t attr -n portHeader -v '${TOMCAT_REMOTE_IP_PORT_HEADER:-X-Forwarded-Port}' \
+  -a "$host/Valve[last()]" -t attr -n remoteIpHeader -v '${TOMCAT_REMOTE_IP_HEADER:-X-Forwarded-For}' \
+  -a "$host/Valve[last()]" -t attr -n protocolHeader -v '${TOMCAT_REMOTE_IP_PROTOCOL_HEADER:-X-Forwarded-Proto}' \
+  -a "$host/Valve[last()]" -t attr -n internalProxies -v '${TOMCAT_REMOTE_IP_INTERNAL_PROXIES}' \
+  -a "$host/Valve[last()]" -t attr -n trustedProxies -v '${TOMCAT_REMOTE_IP_TRUSTED_PROXIES:-}' \
   # Do not leak server info within error pages
-  -s '/Server/Service[@name="Catalina"]/Engine[@name="Catalina"]/Host[@name="localhost"]' -t elem -n 'Valve' \
-  -a '/Server/Service[@name="Catalina"]/Engine[@name="Catalina"]/Host[@name="localhost"]/Valve[last()]' -t attr -n className -v org.apache.catalina.valves.ErrorReportValve \
-  -a '/Server/Service[@name="Catalina"]/Engine[@name="Catalina"]/Host[@name="localhost"]/Valve[last()]' -t attr -n showServerInfo -v false \
-  -a '/Server/Service[@name="Catalina"]/Engine[@name="Catalina"]/Host[@name="localhost"]/Valve[last()]' -t attr -n showReport -v false \
+  -s "$host" -t elem -n 'Valve' \
+  -a "$host/Valve[last()]" -t attr -n className -v org.apache.catalina.valves.ErrorReportValve \
+  -a "$host/Valve[last()]" -t attr -n showServerInfo -v '${TOMCAT_ERROR_REPORT_SHOW_SERVER_INFO:-false}' \
+  -a "$host/Valve[last()]" -t attr -n showReport -v '${TOMCAT_ERROR_REPORT_SHOW_REPORT:-false}' \
   # Do not leak runtime arguments and variables in logs
-  -a '/Server/Listener[@className="org.apache.catalina.startup.VersionLoggerListener"]' -t attr -n logArgs -v false \
-  -a '/Server/Listener[@className="org.apache.catalina.startup.VersionLoggerListener"]' -t attr -n logEnv -v false \
-  -a '/Server/Listener[@className="org.apache.catalina.startup.VersionLoggerListener"]' -t attr -n logProps -v false \
+  -a "$version_logger" -t attr -n logArgs -v '${TOMCAT_VERSION_LOGGER_LOG_ARGS:-false}' \
+  -a "$version_logger" -t attr -n logEnv -v '${TOMCAT_VERSION_LOGGER_LOG_ENV:-false}' \
+  -a "$version_logger" -t attr -n logProps -v '${TOMCAT_VERSION_LOGGER_LOG_PROPS:-false}' \
   conf/server.xml
 # Remove unwanted files from distribution
 RUN rm -fr webapps/* *.txt *.md RELEASE-NOTES logs/ temp/ work/ bin/*.bat
@@ -109,6 +127,11 @@ ENV CATALINA_HOME=/usr/local/tomcat
 ENV TOMCAT_NATIVE_LIBDIR=$CATALINA_HOME/native-jni-lib
 ENV LD_LIBRARY_PATH=$TOMCAT_NATIVE_LIBDIR
 ENV PATH=$CATALINA_HOME/bin:$PATH
+
+# The only TOMCAT_* default not inlined in server.xml: Tomcat ends a ${...:-default}
+# at the first '}', which this regex contains. Quoting keeps the backslashes.
+ENV TOMCAT_REMOTE_IP_INTERNAL_PROXIES="10\.\d{1,3}\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}|169\.254\.\d{1,3}\.\d{1,3}|127\.\d{1,3}\.\d{1,3}\.\d{1,3}|100\.6[4-9]{1}\.\d{1,3}\.\d{1,3}|100\.[7-9]{1}\d{1}\.\d{1,3}\.\d{1,3}|100\.1[0-1]{1}\d{1}\.\d{1,3}\.\d{1,3}|100\.12[0-7]{1}\.\d{1,3}\.\d{1,3}|172\.1[6-9]{1}\.\d{1,3}\.\d{1,3}|172\.2[0-9]{1}\.\d{1,3}\.\d{1,3}|172\.3[0-1]{1}\.\d{1,3}\.\d{1,3}|0:0:0:0:0:0:0:1|::1|fe[89ab]\p{XDigit}:.*|f[cd]\p{XDigit}{2}+:.*"
+
 WORKDIR $CATALINA_HOME
 # fix permissions (especially for running as non-root)
 # https://github.com/docker-library/tomcat/issues/35

--- a/tomcat/Dockerfile
+++ b/tomcat/Dockerfile
@@ -54,6 +54,11 @@ RUN echo 'org.apache.tomcat.util.digester.PROPERTY_SOURCE=org.apache.tomcat.util
 RUN connector='/Server/Service[@name="Catalina"]/Connector[@protocol="HTTP/1.1"]'; \
   host='/Server/Service[@name="Catalina"]/Engine[@name="Catalina"]/Host[@name="localhost"]'; \
   version_logger='/Server/Listener[@className="org.apache.catalina.startup.VersionLoggerListener"]'; \
+  if [ "$TOMCAT_MAJOR" = "11" ]; then \
+    internal_proxies='TOMCAT_REMOTE_IP_INTERNAL_PROXIES:-10/8,172.16/12,192.168/16,169.254/16,100.64/10,127/8,::1,fe80::/10,fc00::/7'; \
+  else \
+    internal_proxies='TOMCAT_REMOTE_IP_INTERNAL_PROXIES_TOMCAT10_REGEX'; \
+  fi; \
   xmlstarlet ed -L \
   # Remove comments
   -d '//comment()' \
@@ -80,7 +85,7 @@ RUN connector='/Server/Service[@name="Catalina"]/Connector[@protocol="HTTP/1.1"]
   -a "$host/Valve[last()]" -t attr -n portHeader -v '${TOMCAT_REMOTE_IP_PORT_HEADER:-X-Forwarded-Port}' \
   -a "$host/Valve[last()]" -t attr -n remoteIpHeader -v '${TOMCAT_REMOTE_IP_HEADER:-X-Forwarded-For}' \
   -a "$host/Valve[last()]" -t attr -n protocolHeader -v '${TOMCAT_REMOTE_IP_PROTOCOL_HEADER:-X-Forwarded-Proto}' \
-  -a "$host/Valve[last()]" -t attr -n internalProxies -v '${TOMCAT_REMOTE_IP_INTERNAL_PROXIES}' \
+  -a "$host/Valve[last()]" -t attr -n internalProxies -v "\${$internal_proxies}" \
   -a "$host/Valve[last()]" -t attr -n trustedProxies -v '${TOMCAT_REMOTE_IP_TRUSTED_PROXIES:-}' \
   # Do not leak server info within error pages
   -s "$host" -t elem -n 'Valve' \
@@ -123,6 +128,7 @@ FROM apr_pkg-rockylinux AS apr_pkg-rhel
 
 # hadolint ignore=DL3006
 FROM apr_pkg-${DISTRIB_NAME}
+ARG TOMCAT_MAJOR
 
 ENV CATALINA_HOME=/usr/local/tomcat
 # let "Tomcat Native" live somewhere isolated
@@ -130,9 +136,9 @@ ENV TOMCAT_NATIVE_LIBDIR=$CATALINA_HOME/native-jni-lib
 ENV LD_LIBRARY_PATH=$TOMCAT_NATIVE_LIBDIR
 ENV PATH=$CATALINA_HOME/bin:$PATH
 
-# The only TOMCAT_* default not inlined in server.xml: Tomcat ends a ${...:-default}
-# at the first '}', which this regex contains. Quoting keeps the backslashes.
-ENV TOMCAT_REMOTE_IP_INTERNAL_PROXIES="10\.\d{1,3}\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}|169\.254\.\d{1,3}\.\d{1,3}|127\.\d{1,3}\.\d{1,3}\.\d{1,3}|100\.6[4-9]{1}\.\d{1,3}\.\d{1,3}|100\.[7-9]{1}\d{1}\.\d{1,3}\.\d{1,3}|100\.1[0-1]{1}\d{1}\.\d{1,3}\.\d{1,3}|100\.12[0-7]{1}\.\d{1,3}\.\d{1,3}|172\.1[6-9]{1}\.\d{1,3}\.\d{1,3}|172\.2[0-9]{1}\.\d{1,3}\.\d{1,3}|172\.3[0-1]{1}\.\d{1,3}\.\d{1,3}|0:0:0:0:0:0:0:1|::1|fe[89ab]\p{XDigit}:.*|f[cd]\p{XDigit}{2}+:.*"
+# Tomcat 10 only: regex-based internal proxies (will be removed when Tomcat 10 is deprecated).
+# Tomcat 11+ uses CIDR notation directly, which is more readable and natively supported.
+ENV TOMCAT_REMOTE_IP_INTERNAL_PROXIES_TOMCAT10_REGEX="10\.\d{1,3}\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}|169\.254\.\d{1,3}\.\d{1,3}|127\.\d{1,3}\.\d{1,3}\.\d{1,3}|100\.6[4-9]{1}\.\d{1,3}\.\d{1,3}|100\.[7-9]{1}\d{1}\.\d{1,3}\.\d{1,3}|100\.1[0-1]{1}\d{1}\.\d{1,3}\.\d{1,3}|100\.12[0-7]{1}\.\d{1,3}\.\d{1,3}|172\.1[6-9]{1}\.\d{1,3}\.\d{1,3}|172\.2[0-9]{1}\.\d{1,3}\.\d{1,3}|172\.3[0-1]{1}\.\d{1,3}\.\d{1,3}|0:0:0:0:0:0:0:1|::1|fe[89ab]\p{XDigit}:.*|f[cd]\p{XDigit}{2}+:.*"
 
 WORKDIR $CATALINA_HOME
 # fix permissions (especially for running as non-root)

--- a/tomcat/README.md
+++ b/tomcat/README.md
@@ -1,0 +1,147 @@
+# Alfresco Base Tomcat image
+
+## Description
+
+This Docker file is used to build the base Tomcat image every Alfresco Java web
+application image is derived from. It ships Apache Tomcat (10.1 or 11.0,
+depending on the ACS version being built) together with the Tomcat Native
+library, and applies a set of hardening defaults to `conf/server.xml`.
+
+## Building the image
+
+You can build the image from the root of this git repository with the following
+command:
+
+```bash
+docker buildx bake tomcat_base
+```
+
+## Running the image
+
+### Tomcat configuration
+
+The Tomcat settings that are most commonly tuned are exposed as environment
+variables, all prefixed with `TOMCAT_`. Every variable has a default that
+reproduces the behaviour of the image when the variable is left alone, so you
+only need to set the ones you actually want to change:
+
+```bash
+docker run -e TOMCAT_HTTP_MAX_THREADS=400 -e TOMCAT_HTTP_MAX_POST_SIZE=104857600 \
+  alfresco-content-repository:mytag
+```
+
+This relies on Tomcat's own [property replacement][systemprops] mechanism: the
+image registers `org.apache.tomcat.util.digester.EnvironmentPropertySource` in
+`conf/catalina.properties`, which makes Tomcat resolve the `${...}` placeholders
+in `conf/server.xml` against the container's environment when it starts. The
+values are therefore read at container startup, not at build time, and the same
+variables work in every image built on top of this one.
+
+[systemprops]: https://tomcat.apache.org/tomcat-10.1-doc/config/systemprops.html#Property_replacements
+
+#### Server
+
+See the [Server][server] documentation.
+
+| Variable | Default | Description |
+|---|---|---|
+| `TOMCAT_SHUTDOWN_PORT` | `-1` | Port listening for the shutdown command. Disabled by default |
+| `TOMCAT_VERSION_LOGGER_LOG_ARGS` | `false` | Log the JVM command line arguments at startup |
+| `TOMCAT_VERSION_LOGGER_LOG_ENV` | `false` | Log the environment variables at startup |
+| `TOMCAT_VERSION_LOGGER_LOG_PROPS` | `false` | Log the JVM system properties at startup |
+
+[server]: https://tomcat.apache.org/tomcat-10.1-doc/config/server.html
+
+#### HTTP connector
+
+See the [HTTP connector][http] documentation.
+
+| Variable | Default | Description |
+|---|---|---|
+| `TOMCAT_HTTP_PORT` | `8080` | TCP port the HTTP connector listens on |
+| `TOMCAT_HTTP_CONNECTION_TIMEOUT` | `20000` | Milliseconds to wait for the request line after accepting a connection |
+| `TOMCAT_HTTP_MAX_THREADS` | `200` | Maximum number of request processing threads |
+| `TOMCAT_HTTP_MIN_SPARE_THREADS` | `10` | Number of threads kept running even when idle |
+| `TOMCAT_HTTP_ACCEPT_COUNT` | `100` | Length of the OS accept queue used once all threads are busy |
+| `TOMCAT_HTTP_MAX_CONNECTIONS` | `8192` | Maximum number of concurrent connections |
+| `TOMCAT_HTTP_MAX_HTTP_HEADER_SIZE` | `8192` | Maximum size in bytes of the request and response headers |
+| `TOMCAT_HTTP_MAX_POST_SIZE` | `2097152` | Maximum size in bytes of a form POST body. Raise it for large uploads |
+
+`TOMCAT_HTTP_PORT` only changes the port Tomcat binds inside the container. The
+image declares `EXPOSE 8080`, so if you move the connector you also need to
+publish the new port yourself.
+
+[http]: https://tomcat.apache.org/tomcat-10.1-doc/config/http.html
+
+#### Web application deployment
+
+See the [Host][host] documentation. Applications are baked into the derived
+images, so automatic deployment is switched off by default.
+
+| Variable | Default | Description |
+|---|---|---|
+| `TOMCAT_DEPLOY_XML` | `false` | Parse the `META-INF/context.xml` embedded in web applications |
+| `TOMCAT_AUTO_DEPLOY` | `false` | Deploy new or updated applications while Tomcat is running |
+| `TOMCAT_UNPACK_WARS` | `false` | Unpack WAR files before running them |
+
+[host]: https://tomcat.apache.org/tomcat-10.1-doc/config/host.html
+
+#### Reverse proxy handling
+
+The image enables the [RemoteIpValve][valve] so that the client address, host,
+port and protocol reported to the application reflect what the client sent to
+the reverse proxy rather than the proxy's own connection.
+
+| Variable | Default | Description |
+|---|---|---|
+| `TOMCAT_REMOTE_IP_HEADER` | `X-Forwarded-For` | Header carrying the originating client address |
+| `TOMCAT_REMOTE_IP_PROTOCOL_HEADER` | `X-Forwarded-Proto` | Header carrying the protocol the client used |
+| `TOMCAT_REMOTE_IP_PORT_HEADER` | `X-Forwarded-Port` | Header carrying the port the client connected to |
+| `TOMCAT_REMOTE_IP_INTERNAL_PROXIES` | private and loopback ranges | Regular expression matching the proxies whose forwarded headers are trusted |
+| `TOMCAT_REMOTE_IP_TRUSTED_PROXIES` | *(empty)* | Regular expression matching proxies that are trusted but should still appear in the proxies header |
+
+The default `TOMCAT_REMOTE_IP_INTERNAL_PROXIES` is the regular expression Tomcat
+itself ships, covering `10/8`, `172.16/12`, `192.168/16`, `169.254/16`,
+`100.64/10`, `127/8`, `::1`, `fe80::/10` and `fc00::/7`. Set it to the address of
+your ingress if you want to be stricter. Note that Tomcat 11 accepts CIDR
+notation here but Tomcat 10 does not, so use a regular expression if you build
+images for both.
+
+Unlike the other variables, this one gets its default from an `ENV` in the
+Dockerfile rather than from `server.xml`, because the regular expression contains
+a closing brace. See the note at the end of this page.
+
+[valve]: https://tomcat.apache.org/tomcat-10.1-doc/config/valve.html#Remote_IP_Valve
+
+#### Error pages
+
+See the [ErrorReportValve][errorvalve] documentation. Both are off by default so
+that error pages do not leak information about the server or the application.
+
+| Variable | Default | Description |
+|---|---|---|
+| `TOMCAT_ERROR_REPORT_SHOW_SERVER_INFO` | `false` | Include the Tomcat version in error pages |
+| `TOMCAT_ERROR_REPORT_SHOW_REPORT` | `false` | Include the exception and stack trace in error pages |
+
+[errorvalve]: https://tomcat.apache.org/tomcat-10.1-doc/config/valve.html#Error_Report_Valve
+
+### Beyond these variables
+
+Anything not covered above can still be configured:
+
+- JVM options, including any Tomcat [system property][systemprops] that is not
+  exposed here, go in `JAVA_OPTS` or `CATALINA_OPTS`, for example
+  `-e CATALINA_OPTS="-Dorg.apache.catalina.STRICT_SERVLET_COMPLIANCE=true"`.
+- Settings that live in `conf/catalina.properties`, such as the JAR scanning
+  filters `tomcat.util.scan.StandardJarScanFilter.jarsToSkip` and `jarsToScan`,
+  cannot be overridden with `-D`: Tomcat loads that file over the top of the
+  system properties. Replace the file, or edit it in a derived image.
+- For anything else, mount your own `conf/server.xml` over
+  `/usr/local/tomcat/conf/server.xml`. Environment variable substitution stays
+  available, so your file can use `${...}` placeholders too.
+
+Two behaviours are worth knowing about when overriding these variables. Setting
+one to an empty string is not the same as leaving it unset: the empty value is
+substituted into `server.xml`, which for most attributes means "disabled". And a
+value containing a closing brace cannot be used, because Tomcat ends the
+placeholder at the first `}` it finds.

--- a/tomcat/README.md
+++ b/tomcat/README.md
@@ -109,7 +109,7 @@ images for both.
 
 Unlike the other variables, this one gets its default from an `ENV` in the
 Dockerfile rather than from `server.xml`, because the regular expression contains
-a closing brace. See the note at the end of this page.
+a closing brace.
 
 [valve]: https://tomcat.apache.org/tomcat-10.1-doc/config/valve.html#Remote_IP_Valve
 
@@ -140,8 +140,6 @@ Anything not covered above can still be configured:
   `/usr/local/tomcat/conf/server.xml`. Environment variable substitution stays
   available, so your file can use `${...}` placeholders too.
 
-Two behaviours are worth knowing about when overriding these variables. Setting
-one to an empty string is not the same as leaving it unset: the empty value is
-substituted into `server.xml`, which for most attributes means "disabled". And a
-value containing a closing brace cannot be used, because Tomcat ends the
-placeholder at the first `}` it finds.
+One behaviour worth knowing about when overriding these variables: setting
+one to an empty string is not the same as leaving it unset. The empty value is
+substituted into `server.xml`, which for most attributes means "disabled".

--- a/tomcat/README.md
+++ b/tomcat/README.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-This Docker file is used to build the base Tomcat image every Alfresco Java web
+This Dockerfile is used to build the base Tomcat image that every Alfresco Java web
 application image is derived from. It ships Apache Tomcat (10.1 or 11.0,
 depending on the ACS version being built) together with the Tomcat Native
 library, and applies a set of hardening defaults to `conf/server.xml`.

--- a/tomcat/README.md
+++ b/tomcat/README.md
@@ -97,19 +97,13 @@ the reverse proxy rather than the proxy's own connection.
 | `TOMCAT_REMOTE_IP_HEADER` | `X-Forwarded-For` | Header carrying the originating client address |
 | `TOMCAT_REMOTE_IP_PROTOCOL_HEADER` | `X-Forwarded-Proto` | Header carrying the protocol the client used |
 | `TOMCAT_REMOTE_IP_PORT_HEADER` | `X-Forwarded-Port` | Header carrying the port the client connected to |
-| `TOMCAT_REMOTE_IP_INTERNAL_PROXIES` | private and loopback ranges | Regular expression matching the proxies whose forwarded headers are trusted |
+| `TOMCAT_REMOTE_IP_INTERNAL_PROXIES` | `10/8,172.16/12,...` (Tomcat 11+) | CIDR ranges matching the proxies whose forwarded headers are trusted |
+| `TOMCAT_REMOTE_IP_INTERNAL_PROXIES_TOMCAT10_REGEX` | regex (Tomcat 10 only) | Regex matching the proxies (Tomcat 10 compatibility; will be removed when Tomcat 10 is deprecated) |
 | `TOMCAT_REMOTE_IP_TRUSTED_PROXIES` | *(empty)* | Regular expression matching proxies that are trusted but should still appear in the proxies header |
 
-The default `TOMCAT_REMOTE_IP_INTERNAL_PROXIES` is the regular expression Tomcat
-itself ships, covering `10/8`, `172.16/12`, `192.168/16`, `169.254/16`,
-`100.64/10`, `127/8`, `::1`, `fe80::/10` and `fc00::/7`. Set it to the address of
-your ingress if you want to be stricter. Note that Tomcat 11 accepts CIDR
-notation here but Tomcat 10 does not, so use a regular expression if you build
-images for both.
+**Tomcat 11+:** `TOMCAT_REMOTE_IP_INTERNAL_PROXIES` defaults to `10/8,172.16/12,192.168/16,169.254/16,100.64/10,127/8,::1,fe80::/10,fc00::/7` using CIDR notation. Set it to the address of your ingress if you want to be stricter.
 
-Unlike the other variables, this one gets its default from an `ENV` in the
-Dockerfile rather than from `server.xml`, because the regular expression contains
-a closing brace.
+**Tomcat 10:** Uses `TOMCAT_REMOTE_IP_INTERNAL_PROXIES_TOMCAT10_REGEX` since Tomcat 10 does not support CIDR notation. This variable will be removed once Tomcat 10 is no longer supported.
 
 [valve]: https://tomcat.apache.org/tomcat-10.1-doc/config/valve.html#Remote_IP_Valve
 

--- a/tomcat/tests/tomcat_env_vars_test.sh
+++ b/tomcat/tests/tomcat_env_vars_test.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Test: Verify environment variable substitution works
+IMAGE=$1
+
+out=$(docker run --rm -e TOMCAT_HTTP_PORT=9999 "$IMAGE" catalina.sh configtest 2>&1 || true)
+
+# Check that the env var was applied
+grep -q 'http-nio-9999' <<<"$out" || {
+  echo "Failed: TOMCAT_HTTP_PORT env var not applied to server.xml"
+  echo "$out"
+  exit 1
+}
+
+# Check no unresolved placeholders
+! grep -qE '\$\{|Exception' <<<"$out" || {
+  echo "Failed: Unresolved placeholders or exceptions in output"
+  echo "$out"
+  exit 1
+}
+
+exit 0

--- a/tomcat/tests/tomcat_env_vars_test.sh
+++ b/tomcat/tests/tomcat_env_vars_test.sh
@@ -2,7 +2,11 @@
 # Test: Verify environment variable substitution works
 IMAGE=$1
 
-out=$(docker run --rm -e TOMCAT_HTTP_PORT=9999 "$IMAGE" catalina.sh configtest 2>&1 || true)
+if ! out=$(docker run --rm -e TOMCAT_HTTP_PORT=9999 "$IMAGE" catalina.sh configtest 2>&1); then
+  echo "Failed: catalina.sh configtest exited non-zero"
+  echo "$out"
+  exit 1
+fi
 
 # Check that the env var was applied
 grep -q 'http-nio-9999' <<<"$out" || {

--- a/tomcat/tests/tomcat_native_test.sh
+++ b/tomcat/tests/tomcat_native_test.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Test: Verify Tomcat Native library is loaded
+IMAGE=$1
+
+docker run --rm "$IMAGE" catalina.sh configtest 2>&1 | grep -q "Loaded Apache Tomcat Native library"

--- a/tomcat/tests/tomcat_remote_ip_valve_test.sh
+++ b/tomcat/tests/tomcat_remote_ip_valve_test.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Test: Verify the RemoteIpValve internalProxies attribute references the
+# correct environment variable for the Tomcat major version shipped in the
+# image, and that the fallback regex env var is set for Tomcat 10.
+IMAGE=$1
+
+server_xml=$(docker run --rm "$IMAGE" cat conf/server.xml)
+
+xpath='//Valve[@className="org.apache.catalina.valves.RemoteIpValve"]/@internalProxies'
+internal_proxies=$(xmllint --xpath "$xpath" - <<<"$server_xml" 2>&1) || {
+  echo "Failed: could not extract internalProxies from server.xml"
+  echo "$internal_proxies"
+  exit 1
+}
+
+tomcat_major=$(docker run --rm "$IMAGE" catalina.sh version 2>&1 \
+  | sed -n 's|.*Server number: *\([0-9]*\).*|\1|p')
+
+if [ -z "$tomcat_major" ]; then
+  echo "Failed: could not determine Tomcat major version"
+  exit 1
+fi
+
+if [ "$tomcat_major" = "11" ]; then
+  expected_placeholder='${TOMCAT_REMOTE_IP_INTERNAL_PROXIES:-10/8,172.16/12,192.168/16,169.254/16,100.64/10,127/8,::1,fe80::/10,fc00::/7}'
+else
+  expected_placeholder='${TOMCAT_REMOTE_IP_INTERNAL_PROXIES_TOMCAT10_REGEX}'
+
+  regex_env=$(docker run --rm "$IMAGE" printenv TOMCAT_REMOTE_IP_INTERNAL_PROXIES_TOMCAT10_REGEX)
+  if [ -z "$regex_env" ]; then
+    echo "Failed: TOMCAT_REMOTE_IP_INTERNAL_PROXIES_TOMCAT10_REGEX env var is not set in the image"
+    exit 1
+  fi
+fi
+
+if [[ "$internal_proxies" != *"$expected_placeholder"* ]]; then
+  echo "Failed: internalProxies does not reference the expected env var for Tomcat $tomcat_major"
+  echo "Expected placeholder: $expected_placeholder"
+  echo "Actual attribute: $internal_proxies"
+  exit 1
+fi
+
+exit 0

--- a/tomcat/tests/tomcat_remote_ip_valve_test.sh
+++ b/tomcat/tests/tomcat_remote_ip_valve_test.sh
@@ -4,12 +4,9 @@
 # image, and that the fallback regex env var is set for Tomcat 10.
 IMAGE=$1
 
-server_xml=$(docker run --rm "$IMAGE" cat conf/server.xml)
-
-xpath='//Valve[@className="org.apache.catalina.valves.RemoteIpValve"]/@internalProxies'
-internal_proxies=$(xmllint --xpath "$xpath" - <<<"$server_xml" 2>&1) || {
+internal_proxies=$(docker run --rm "$IMAGE" xmllint --xpath '//Valve[@className="org.apache.catalina.valves.RemoteIpValve"]/@internalProxies' conf/server.xml 2>&1) || {
   echo "Failed: could not extract internalProxies from server.xml"
-  echo "$internal_proxies"
+  echo "$internalProxies"
   exit 1
 }
 

--- a/tomcat/tests/tomcat_remote_ip_valve_test.sh
+++ b/tomcat/tests/tomcat_remote_ip_valve_test.sh
@@ -6,7 +6,7 @@ IMAGE=$1
 
 internal_proxies=$(docker run --rm "$IMAGE" xmllint --xpath '//Valve[@className="org.apache.catalina.valves.RemoteIpValve"]/@internalProxies' conf/server.xml 2>&1) || {
   echo "Failed: could not extract internalProxies from server.xml"
-  echo "$internalProxies"
+  echo "$internal_proxies"
   exit 1
 }
 
@@ -19,13 +19,26 @@ if [ -z "$tomcat_major" ]; then
 fi
 
 if [ "$tomcat_major" = "11" ]; then
+  # shellcheck disable=SC2016  # the literal ${...} placeholder is the expected value
   expected_placeholder='${TOMCAT_REMOTE_IP_INTERNAL_PROXIES:-10/8,172.16/12,192.168/16,169.254/16,100.64/10,127/8,::1,fe80::/10,fc00::/7}'
 else
+  # shellcheck disable=SC2016  # the literal ${...} placeholder is the expected value
   expected_placeholder='${TOMCAT_REMOTE_IP_INTERNAL_PROXIES_TOMCAT10_REGEX}'
 
+  # Compare against the Dockerfile value: an unquoted ENV strips the
+  # backslashes, leaving a still-valid but wrong pattern
+  expected_regex=$(sed -n 's/^ENV TOMCAT_REMOTE_IP_INTERNAL_PROXIES_TOMCAT10_REGEX="\(.*\)"$/\1/p' \
+    "$(dirname "${BASH_SOURCE[0]}")/../Dockerfile")
+  if [ -z "$expected_regex" ]; then
+    echo "Failed: could not read the expected regex from tomcat/Dockerfile"
+    exit 1
+  fi
+
   regex_env=$(docker run --rm "$IMAGE" printenv TOMCAT_REMOTE_IP_INTERNAL_PROXIES_TOMCAT10_REGEX)
-  if [ -z "$regex_env" ]; then
-    echo "Failed: TOMCAT_REMOTE_IP_INTERNAL_PROXIES_TOMCAT10_REGEX env var is not set in the image"
+  if [ "$regex_env" != "$expected_regex" ]; then
+    echo "Failed: TOMCAT_REMOTE_IP_INTERNAL_PROXIES_TOMCAT10_REGEX does not match the Dockerfile value"
+    echo "Expected: $expected_regex"
+    echo "Actual:   $regex_env"
     exit 1
   fi
 fi


### PR DESCRIPTION
### Description

**RFC** — no Jira, at this point. Looking fr comments to decide if it's worth adding.
Today the Tomcat settings in `tomcat/Dockerfile` are baked into `conf/server.xml` at build time with `xmlstarlet`. Changing the thread pool, a timeout, the max POST size or the forwarded header names means forking the image or mounting a whole replacement `server.xml`.

This exposes the commonly tuned ones as `TOMCAT_*` container environment variables, using Tomcat's own [property replacement](https://tomcat.apache.org/tomcat-10.1-doc/config/systemprops.html#Property_replacements) mechanism. `conf/catalina.properties` registers `EnvironmentPropertySource` as the digester property source, and the affected attributes become `${TOMCAT_*:-default}` placeholders that Tomcat resolves from the environment at startup. Every default reproduces the current behaviour, so nothing changes unless a variable is set, and the variables work identically in the repository, share and process services images built on top.

Covered: the settings that were already hardcoded (shutdown port, deployment flags, RemoteIpValve, ErrorReportValve, VersionLoggerListener) plus connector sizing and timeouts, and the remaining RemoteIpValve headers and proxy patterns. Full table in `tomcat/README.md`.

### Notes for reviewers

Three things worth knowing about:

`internalProxies` is the one default that could not be inlined. Tomcat ends a `${...:-default}` at the **first** `}` it finds, and the stock regex contains several, so the default truncated to `10\.\d{1,3` and threw `PatternSyntaxException`, killing the valve on Tomcat 10. It is an `ENV` instead — the only one — and it has to stay quoted, because an unquoted Dockerfile `ENV` strips the backslashes and silently corrupts the pattern. The last commit adds a build-time check so neither failure mode can reach an image again.

Defaults live in `server.xml` rather than as `ENV` lines, which keeps them in one place but means they are not visible in `docker inspect`. Happy to revisit if you would rather trade the noise for discoverability.

Two things are deliberately not exposed. JAR scan tuning (`tomcat.util.scan.StandardJarScanFilter.*`) cannot work this way, since `CatalinaProperties` loads `catalina.properties` over the top of any `-D`; the README says so and points at the alternatives. And `keepAliveTimeout` is left out because its default tracks `connectionTimeout`, and pinning a literal would quietly break that link.

### Testing

Built and ran both Tomcat majors (10.1 via `ACS_VERSION=25.1`, 11.0 by default):

- clean startup on both, no warnings, no unresolved placeholders
- overrides applied, verified on the bound port
- the empty (`:-`) and negative (`:--1`) inline defaults both parse correctly
- as a control, an invalid regex in `TOMCAT_REMOTE_IP_INTERNAL_PROXIES` / `TOMCAT_REMOTE_IP_TRUSTED_PROXIES` is rejected with `PatternSyntaxException`, confirming the values genuinely reach the valve rather than being silently ignored
- a deliberately bogus attribute does produce `WARNING ... failed to set property`, and the real images produce none, so every attribute name is accepted on both majors

`pre-commit` passes. hadolint gains one info-level `DL3059`, and already exits non-zero on `main`.

### Related Issue

N/A

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have updated the documentation accordingly.
