### PR TITLE
OPSEXP-4342: Make Repository and Share modules independently overridable

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,18 @@ specific folders:
 - Additional JAR files for the JRE in the [libs](repository/libs/README.md)
   folder
 
+These sources use named Docker Bake build contexts with the folders above as
+their defaults. Each source can be customized independently with `--set`:
+
+```sh
+docker buildx bake repository \
+  --set repository.contexts.repo_libs=./custom-libs
+```
+
+Repository contexts are `repo_amps`, `repo_amps_edition`, `repo_libs`, and
+`repo_simple_modules`. The replacement directory is used as the root of the
+corresponding build context.
+
 ### Customizing the Share image
 
 The Share image can be customized by adding files into specific folders:
@@ -181,6 +193,17 @@ The Share image can be customized by adding files into specific folders:
   folder
 - Share Simple Module (JAR) files in the
   [simple_modules](share/simple_modules/README.md) folder
+
+These sources use named Docker Bake build contexts with the folders above as
+their defaults. Each source can be customized independently with `--set`:
+
+```sh
+docker buildx bake share \
+  --set share.contexts.share_amps=./custom-share-amps
+```
+
+Share contexts are `share_amps` and `share_simple_modules`. The replacement
+directory is used as the root of the corresponding build context.
 
 ### Customizing the Community Batch Indexing image
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -298,6 +298,10 @@ target "repository" {
   inherits = ["tomcat_base"]
   contexts = {
     tomcat_base = "target:tomcat_base"
+    repo_amps = "./repository/amps"
+    repo_amps_edition = "./repository/amps_${repository_editions.name}"
+    repo_libs = "./repository/libs"
+    repo_simple_modules = "./repository/simple_modules"
   }
   args = {
     ALFRESCO_REPO_GROUP_ID = "${ALFRESCO_GROUP_ID}"
@@ -305,7 +309,6 @@ target "repository" {
     ALFRESCO_REPO_USER_ID = "${ALFRESCO_REPO_USER_ID}"
     ALFRESCO_REPO_USER_NAME = "${ALFRESCO_REPO_USER_NAME}"
     ALFRESCO_REPO_ARTIFACT = "${repository_editions.artifact}"
-    ALFRESCO_REPO_EDITION = "${repository_editions.name}"
   }
   labels = {
     "org.label-schema.name" = "${PRODUCT_LINE} Content Repository (${repository_editions.name})"
@@ -751,6 +754,8 @@ target "share" {
   inherits = ["tomcat_base"]
   contexts = {
     tomcat_base = "target:tomcat_base"
+    share_amps = "./share/amps"
+    share_simple_modules = "./share/simple_modules"
   }
   args = {
     ALFRESCO_SHARE_GROUP_NAME = "${ALFRESCO_GROUP_NAME}"

--- a/repository/Dockerfile
+++ b/repository/Dockerfile
@@ -6,8 +6,6 @@ ARG ALFRESCO_REPO_GROUP_ID
 FROM tomcat_base AS repo_build
 
 ARG ALFRESCO_REPO_ARTIFACT
-ARG ALFRESCO_REPO_EDITION
-
 USER root
 RUN yum install -y unzip
 
@@ -31,9 +29,9 @@ RUN sed -i \
   -re "s|(appender.rolling.filePattern=)(alfresco.log.%d\{yyyy-MM-dd\})|\1${CATALINA_HOME}/logs\/\2|" \
   ${CATALINA_HOME}/webapps/alfresco/WEB-INF/classes/log4j*.properties
 
-COPY amps /tmp/amps
-COPY amps_${ALFRESCO_REPO_EDITION} /tmp/amps
-COPY libs ${CATALINA_HOME}/lib/
+COPY --from=repo_amps / /tmp/amps
+COPY --from=repo_amps_edition / /tmp/amps
+COPY --from=repo_libs / ${CATALINA_HOME}/lib/
 RUN if [ -f /tmp/amps/alfresco-aos-module-*.amp ]; then umask 0027; \
      unzip ${DISTDIR}/web-server/webapps/ROOT.war -d ${CATALINA_HOME}/webapps/ROOT/; \
      cp ${CATALINA_HOME}/webapps/ROOT/META-INF/context.xml ${CATALINA_HOME}/conf/Catalina/localhost/ROOT.xml; \
@@ -44,7 +42,7 @@ RUN java -jar ${DISTDIR}/bin/alfresco-mmt.jar install \
     /tmp/amps/ ${CATALINA_HOME}/webapps/alfresco -nobackup -directory -force && \
     java -jar ${DISTDIR}/bin/alfresco-mmt.jar list ${CATALINA_HOME}/webapps/alfresco
 
-COPY simple_modules /tmp/simple_modules
+COPY --from=repo_simple_modules / /tmp/simple_modules
 RUN mkdir -m 750 -p ${CATALINA_HOME}/modules/platform && \
     for jar in /tmp/simple_modules/*.jar; do \
       if [ -f "$jar" ]; then \

--- a/share/Dockerfile
+++ b/share/Dockerfile
@@ -15,7 +15,7 @@ COPY entrypoint.sh ${CATALINA_HOME}/shared/classes/alfresco
 ARG ALFRESCO_SHARE_ARTIFACT
 
 COPY distribution/${ALFRESCO_SHARE_ARTIFACT}-*.zip /tmp/
-COPY amps /tmp/amps
+COPY --from=share_amps / /tmp/amps
 
 ENV DISTDIR="/tmp/distribution"
 
@@ -33,7 +33,7 @@ RUN java -jar ${DISTDIR}/bin/alfresco-mmt.jar install \
     /tmp/amps/ ${CATALINA_HOME}/webapps/share -directory -nobackup -force && \
     java -jar ${DISTDIR}/bin/alfresco-mmt.jar list ${CATALINA_HOME}/webapps/share
 
-COPY simple_modules /tmp/simple_modules
+COPY --from=share_simple_modules / /tmp/simple_modules
 RUN mkdir -m 750 -p ${CATALINA_HOME}/modules/share && \
     for jar in /tmp/simple_modules/*.jar; do \
       if [ -f "$jar" ]; then \


### PR DESCRIPTION
## Problem

Repository and Share customizations are currently tied to the directories checked into this repository. When a downstream build needs to provide a different set of AMPs, libraries, or simple modules, it cannot override one source independently through Docker Bake; it must modify or replace the in-tree content. This makes product-specific and extension builds harder to maintain.

## Solution

- Add named Docker Bake build contexts for Repository AMPs, edition-specific AMPs, libraries, and simple modules.
- Add named build contexts for Share AMPs and simple modules.
- Keep the existing repository directories as the default sources, preserving current builds.
- Allow each source to be overridden independently with `docker buildx bake --set`.

This PR implements OPSEXP-4323